### PR TITLE
chore: dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,10 +12,11 @@ updates:
     schedule:
       interval: "monthly"
     groups:
-      storybook:
-        patterns:
-          - "storybook"
-          - "@storybook/*"
+      patch-and-minor-updates:
+        applies-to: "version-updates"
+        update-types:
+          - "patch"
+          - "minor"
     versioning-strategy: "increase-if-necessary"
     open-pull-requests-limit: 20
     reviewers:


### PR DESCRIPTION
Group all patch and minor version bumps in one pull request.

Dependabot pull requests mainly serve as a reminder and are normally not merged because we use our own pnpm update-patch/minor/major scripts to create pull requests.

This change should bring down the number of pull requests down significantly while still serving as the reminder we want.