### PR TITLE
chore: add publishConfig

### DIFF
--- a/packages/components-css/paragraph-css/package.json
+++ b/packages/components-css/paragraph-css/package.json
@@ -16,6 +16,9 @@
     "url": "git@github.com:nl-design-system/candidate.git",
     "directory": "packages/components-css/paragraph-css"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "build": "sass ./src/:./dist/",
     "clean": "rimraf ./dist/"

--- a/packages/components-react/paragraph-react/package.json
+++ b/packages/components-react/paragraph-react/package.json
@@ -23,6 +23,9 @@
     "url": "git@github.com:nl-design-system/candidate.git",
     "directory": "packages/components-react/paragraph-react"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "build": "rollup --config ./rollup.config.mjs",
     "clean": "rimraf ./dist/ ./*.tsbuildinfo ./.rollup.cache/",


### PR DESCRIPTION
Scoped packages are private by default and need a `publishConfig` with `"access": "public"` to be published to the npm registry.