### PR TITLE
chore: replace Sass @imports

### DIFF
--- a/packages/components-css/paragraph-css/src/html/_mixins.scss
+++ b/packages/components-css/paragraph-css/src/html/_mixins.scss
@@ -1,7 +1,7 @@
-@import "../mixins";
+@use "../mixins";
 
 @mixin p {
   p {
-    @include nl-paragraph;
+    @include mixins.nl-paragraph;
   }
 }

--- a/packages/components-css/paragraph-css/src/html/paragraph.scss
+++ b/packages/components-css/paragraph-css/src/html/paragraph.scss
@@ -1,3 +1,3 @@
-@import "./mixins";
+@use "mixins";
 
-@include p;
+@include mixins.p;

--- a/packages/components-css/paragraph-css/src/paragraph.scss
+++ b/packages/components-css/paragraph-css/src/paragraph.scss
@@ -1,17 +1,17 @@
-@import "./mixins";
+@use "mixins";
 
 .nl-paragraph {
-  @include nl-paragraph;
+  @include mixins.nl-paragraph;
 }
 
 .nl-paragraph--lead {
-  @include nl-paragraph--lead;
+  @include mixins.nl-paragraph--lead;
 }
 
 .nl-paragraph--small {
-  @include nl-paragraph--small;
+  @include mixins.nl-paragraph--small;
 }
 
 .nl-paragraph__b {
-  @include nl-paragraph__b;
+  @include mixins.nl-paragraph__b;
 }


### PR DESCRIPTION
See https://sass-lang.com/blog/import-is-deprecated/ for more information