### PR TITLE
refactor(paragraph-css): rename _mixins

### DIFF
--- a/.changeset/ten-drinks-lay.md
+++ b/.changeset/ten-drinks-lay.md
@@ -1,0 +1,5 @@
+---
+'@nl-design-system-candidate/paragraph-css': major
+---
+
+Rename `_mixins.scss` to `_mixin.scss`, update imports accordingly

--- a/packages/components-css/paragraph-css/src/_mixin.scss
+++ b/packages/components-css/paragraph-css/src/_mixin.scss
@@ -16,7 +16,7 @@
 }
 
 @mixin nl-paragraph--small {
-  color: var(--nl-paragraph-small-color, var(--nl-paragraph-color,  inherit));
+  color: var(--nl-paragraph-small-color, var(--nl-paragraph-color, inherit));
   font-size: var(--nl-paragraph-small-font-size, var(--nl-paragraph-font-size, inherit));
   font-weight: var(--nl-paragraph-small-font-weight, var(--nl-paragraph-font-weight, inherit));
   line-height: var(--nl-paragraph-small-line-height, var(--nl-paragraph-line-height, inherit));

--- a/packages/components-css/paragraph-css/src/html/_mixin.scss
+++ b/packages/components-css/paragraph-css/src/html/_mixin.scss
@@ -1,0 +1,7 @@
+@use "../mixin";
+
+@mixin p {
+  p {
+    @include mixin.nl-paragraph;
+  }
+}

--- a/packages/components-css/paragraph-css/src/html/_mixins.scss
+++ b/packages/components-css/paragraph-css/src/html/_mixins.scss
@@ -1,7 +1,0 @@
-@use "../mixins";
-
-@mixin p {
-  p {
-    @include mixins.nl-paragraph;
-  }
-}

--- a/packages/components-css/paragraph-css/src/html/paragraph.scss
+++ b/packages/components-css/paragraph-css/src/html/paragraph.scss
@@ -1,3 +1,3 @@
-@use "mixins";
+@use "mixin";
 
-@include mixins.p;
+@include mixin.p;

--- a/packages/components-css/paragraph-css/src/paragraph.scss
+++ b/packages/components-css/paragraph-css/src/paragraph.scss
@@ -1,17 +1,17 @@
-@use "mixins";
+@use "mixin";
 
 .nl-paragraph {
-  @include mixins.nl-paragraph;
+  @include mixin.nl-paragraph;
 }
 
 .nl-paragraph--lead {
-  @include mixins.nl-paragraph--lead;
+  @include mixin.nl-paragraph--lead;
 }
 
 .nl-paragraph--small {
-  @include mixins.nl-paragraph--small;
+  @include mixin.nl-paragraph--small;
 }
 
 .nl-paragraph__b {
-  @include mixins.nl-paragraph__b;
+  @include mixin.nl-paragraph__b;
 }


### PR DESCRIPTION
Rename `_mixins.scss` -> `_mixin.scss`. We prefer singular over plural in these instances