### PR TITLE
build: use shared rollup config

### DIFF
--- a/packages/components-react/heading-1-react/rollup.config.mjs
+++ b/packages/components-react/heading-1-react/rollup.config.mjs
@@ -1,28 +1,7 @@
-import babel from '@rollup/plugin-babel';
-import nodeResolve from '@rollup/plugin-node-resolve';
-import typescript from '@rollup/plugin-typescript';
-import nodeExternals from 'rollup-plugin-node-externals';
-import peerDepsExternal from 'rollup-plugin-peer-deps-external';
-import postcss from 'rollup-plugin-postcss';
+import { defineConfig } from 'rollup';
+import { rollupConfig } from '../rollupConfig.mjs';
 
-export default {
+export default defineConfig({
   input: ['./src/heading-1.tsx', './src/css.tsx'],
-  output: {
-    dir: './dist/',
-    format: 'es',
-    sourcemap: true, // needed because of tsconfig.build.json
-  },
-  plugins: [
-    peerDepsExternal(),
-    nodeExternals(),
-    nodeResolve({ browser: true }),
-    typescript({ tsconfig: './tsconfig.build.json' }),
-    babel({
-      babelHelpers: 'runtime',
-      extensions: ['.ts', '.tsx'],
-      inputSourceMap: true,
-      plugins: ['@babel/plugin-transform-runtime'],
-    }),
-    postcss(),
-  ],
-};
+  ...rollupConfig,
+});

--- a/packages/components-react/heading-2-react/rollup.config.mjs
+++ b/packages/components-react/heading-2-react/rollup.config.mjs
@@ -1,28 +1,7 @@
-import babel from '@rollup/plugin-babel';
-import nodeResolve from '@rollup/plugin-node-resolve';
-import typescript from '@rollup/plugin-typescript';
-import nodeExternals from 'rollup-plugin-node-externals';
-import peerDepsExternal from 'rollup-plugin-peer-deps-external';
-import postcss from 'rollup-plugin-postcss';
+import { defineConfig } from 'rollup';
+import { rollupConfig } from '../rollupConfig.mjs';
 
-export default {
+export default defineConfig({
   input: ['./src/heading-2.tsx', './src/css.tsx'],
-  output: {
-    dir: './dist/',
-    format: 'es',
-    sourcemap: true, // needed because of tsconfig.build.json
-  },
-  plugins: [
-    peerDepsExternal(),
-    nodeExternals(),
-    nodeResolve({ browser: true }),
-    typescript({ tsconfig: './tsconfig.build.json' }),
-    babel({
-      babelHelpers: 'runtime',
-      extensions: ['.ts', '.tsx'],
-      inputSourceMap: true,
-      plugins: ['@babel/plugin-transform-runtime'],
-    }),
-    postcss(),
-  ],
-};
+  ...rollupConfig,
+});

--- a/packages/components-react/heading-3-react/rollup.config.mjs
+++ b/packages/components-react/heading-3-react/rollup.config.mjs
@@ -1,28 +1,7 @@
-import babel from '@rollup/plugin-babel';
-import nodeResolve from '@rollup/plugin-node-resolve';
-import typescript from '@rollup/plugin-typescript';
-import nodeExternals from 'rollup-plugin-node-externals';
-import peerDepsExternal from 'rollup-plugin-peer-deps-external';
-import postcss from 'rollup-plugin-postcss';
+import { defineConfig } from 'rollup';
+import { rollupConfig } from '../rollupConfig.mjs';
 
-export default {
+export default defineConfig({
   input: ['./src/heading-3.tsx', './src/css.tsx'],
-  output: {
-    dir: './dist/',
-    format: 'es',
-    sourcemap: true, // needed because of tsconfig.build.json
-  },
-  plugins: [
-    peerDepsExternal(),
-    nodeExternals(),
-    nodeResolve({ browser: true }),
-    typescript({ tsconfig: './tsconfig.build.json' }),
-    babel({
-      babelHelpers: 'runtime',
-      extensions: ['.ts', '.tsx'],
-      inputSourceMap: true,
-      plugins: ['@babel/plugin-transform-runtime'],
-    }),
-    postcss(),
-  ],
-};
+  ...rollupConfig,
+});

--- a/packages/components-react/heading-4-react/rollup.config.mjs
+++ b/packages/components-react/heading-4-react/rollup.config.mjs
@@ -1,28 +1,7 @@
-import babel from '@rollup/plugin-babel';
-import nodeResolve from '@rollup/plugin-node-resolve';
-import typescript from '@rollup/plugin-typescript';
-import nodeExternals from 'rollup-plugin-node-externals';
-import peerDepsExternal from 'rollup-plugin-peer-deps-external';
-import postcss from 'rollup-plugin-postcss';
+import { defineConfig } from 'rollup';
+import { rollupConfig } from '../rollupConfig.mjs';
 
-export default {
+export default defineConfig({
   input: ['./src/heading-4.tsx', './src/css.tsx'],
-  output: {
-    dir: './dist/',
-    format: 'es',
-    sourcemap: true, // needed because of tsconfig.build.json
-  },
-  plugins: [
-    peerDepsExternal(),
-    nodeExternals(),
-    nodeResolve({ browser: true }),
-    typescript({ tsconfig: './tsconfig.build.json' }),
-    babel({
-      babelHelpers: 'runtime',
-      extensions: ['.ts', '.tsx'],
-      inputSourceMap: true,
-      plugins: ['@babel/plugin-transform-runtime'],
-    }),
-    postcss(),
-  ],
-};
+  ...rollupConfig,
+});

--- a/packages/components-react/heading-5-react/rollup.config.mjs
+++ b/packages/components-react/heading-5-react/rollup.config.mjs
@@ -1,28 +1,7 @@
-import babel from '@rollup/plugin-babel';
-import nodeResolve from '@rollup/plugin-node-resolve';
-import typescript from '@rollup/plugin-typescript';
-import nodeExternals from 'rollup-plugin-node-externals';
-import peerDepsExternal from 'rollup-plugin-peer-deps-external';
-import postcss from 'rollup-plugin-postcss';
+import { defineConfig } from 'rollup';
+import { rollupConfig } from '../rollupConfig.mjs';
 
-export default {
+export default defineConfig({
   input: ['./src/heading-5.tsx', './src/css.tsx'],
-  output: {
-    dir: './dist/',
-    format: 'es',
-    sourcemap: true, // needed because of tsconfig.build.json
-  },
-  plugins: [
-    peerDepsExternal(),
-    nodeExternals(),
-    nodeResolve({ browser: true }),
-    typescript({ tsconfig: './tsconfig.build.json' }),
-    babel({
-      babelHelpers: 'runtime',
-      extensions: ['.ts', '.tsx'],
-      inputSourceMap: true,
-      plugins: ['@babel/plugin-transform-runtime'],
-    }),
-    postcss(),
-  ],
-};
+  ...rollupConfig,
+});

--- a/packages/components-react/heading-6-react/rollup.config.mjs
+++ b/packages/components-react/heading-6-react/rollup.config.mjs
@@ -1,28 +1,7 @@
-import babel from '@rollup/plugin-babel';
-import nodeResolve from '@rollup/plugin-node-resolve';
-import typescript from '@rollup/plugin-typescript';
-import nodeExternals from 'rollup-plugin-node-externals';
-import peerDepsExternal from 'rollup-plugin-peer-deps-external';
-import postcss from 'rollup-plugin-postcss';
+import { defineConfig } from 'rollup';
+import { rollupConfig } from '../rollupConfig.mjs';
 
-export default {
+export default defineConfig({
   input: ['./src/heading-6.tsx', './src/css.tsx'],
-  output: {
-    dir: './dist/',
-    format: 'es',
-    sourcemap: true, // needed because of tsconfig.build.json
-  },
-  plugins: [
-    peerDepsExternal(),
-    nodeExternals(),
-    nodeResolve({ browser: true }),
-    typescript({ tsconfig: './tsconfig.build.json' }),
-    babel({
-      babelHelpers: 'runtime',
-      extensions: ['.ts', '.tsx'],
-      inputSourceMap: true,
-      plugins: ['@babel/plugin-transform-runtime'],
-    }),
-    postcss(),
-  ],
-};
+  ...rollupConfig,
+});

--- a/packages/components-react/paragraph-react/rollup.config.mjs
+++ b/packages/components-react/paragraph-react/rollup.config.mjs
@@ -1,28 +1,7 @@
-import babel from '@rollup/plugin-babel';
-import nodeResolve from '@rollup/plugin-node-resolve';
-import typescript from '@rollup/plugin-typescript';
-import nodeExternals from 'rollup-plugin-node-externals';
-import peerDepsExternal from 'rollup-plugin-peer-deps-external';
-import postcss from 'rollup-plugin-postcss';
+import { defineConfig } from 'rollup';
+import { rollupConfig } from '../rollupConfig.mjs';
 
-export default {
+export default defineConfig({
   input: ['./src/paragraph.tsx', './src/css.tsx'],
-  output: {
-    dir: './dist/',
-    format: 'es',
-    sourcemap: true, // needed because of tsconfig.build.json
-  },
-  plugins: [
-    peerDepsExternal(),
-    nodeExternals(),
-    nodeResolve({ browser: true }),
-    typescript({ tsconfig: './tsconfig.build.json' }),
-    babel({
-      babelHelpers: 'runtime',
-      extensions: ['.ts', '.tsx'],
-      inputSourceMap: true,
-      plugins: ['@babel/plugin-transform-runtime'],
-    }),
-    postcss(),
-  ],
-};
+  ...rollupConfig,
+});

--- a/packages/components-react/rollupConfig.mjs
+++ b/packages/components-react/rollupConfig.mjs
@@ -1,0 +1,28 @@
+import babel from '@rollup/plugin-babel';
+import nodeResolve from '@rollup/plugin-node-resolve';
+import typescript from '@rollup/plugin-typescript';
+import { defineConfig } from 'rollup';
+import nodeExternals from 'rollup-plugin-node-externals';
+import peerDepsExternal from 'rollup-plugin-peer-deps-external';
+import postcss from 'rollup-plugin-postcss';
+
+export const rollupConfig = defineConfig({
+  output: {
+    dir: './dist/',
+    format: 'es',
+    sourcemap: true, // needed because of tsconfig.build.json
+  },
+  plugins: [
+    peerDepsExternal(),
+    nodeExternals(),
+    nodeResolve({ browser: true }),
+    typescript({ tsconfig: './tsconfig.build.json' }),
+    babel({
+      babelHelpers: 'runtime',
+      extensions: ['.ts', '.tsx'],
+      inputSourceMap: true,
+      plugins: ['@babel/plugin-transform-runtime'],
+    }),
+    postcss(),
+  ],
+});


### PR DESCRIPTION
Reduce duplication of the rollup configuration by importing from a higher-level directory instead of repeating the same configuration across multiple packages.