### PR TITLE
feat: add paragraph-docs

### DIFF
--- a/npmpackagejsonlint.config.cjs
+++ b/npmpackagejsonlint.config.cjs
@@ -10,9 +10,9 @@ module.exports = {
   },
   overrides: [
     {
-      patterns: ['proprietary/**/package.json'],
+      patterns: ['packages/docs/**/package.json'],
       rules: {
-        'valid-values-license': ['error', ['SEE LICENSE IN LICENSE.md']],
+        'valid-values-license': ['error', ['CC0-1.0']],
       },
     },
   ],

--- a/packages/docs/paragraph-docs/docs/anatomy.en.md
+++ b/packages/docs/paragraph-docs/docs/anatomy.en.md
@@ -1,0 +1,3 @@
+<!-- @license CC0-1.0 -->
+
+# Anatomy

--- a/packages/docs/paragraph-docs/docs/anatomy.md
+++ b/packages/docs/paragraph-docs/docs/anatomy.md
@@ -1,0 +1,3 @@
+<!-- @license CC0-1.0 -->
+
+# Anatomie

--- a/packages/docs/paragraph-docs/package.json
+++ b/packages/docs/paragraph-docs/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@nl-design-system-candidate/paragraph-docs",
+  "version": "0.0.0",
+  "description": "Documentatie voor het Paragraph component",
+  "license": "CC0-1.0",
+  "homepage": "https://github.com/nl-design-system/candidate/tree/main/packages/docs/paragraph-docs#readme",
+  "scripts": {},
+  "keywords": [
+    "nl-design-system",
+    "paragraph",
+    "paragraph-component"
+  ],
+  "files": [
+    "./docs/"
+  ],
+  "repository": {
+    "type": "git+ssh",
+    "url": "git@github.com:nl-design-system/candidate.git",
+    "directory": "packages/docs/paragraph-docs"
+  },
+  "private": true,
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,3 +2,4 @@ packages:
   - packages/*
   - packages/components-react/*
   - packages/components-css/*
+  - packages/docs/*


### PR DESCRIPTION
- Add an override to npmpackagejsonlint.config.cjs to allow the CC0-1.0 license