### PR TITLE
fix: rename paragraph BEM class name element `__b` to `__lead`

### DIFF
--- a/.changeset/thick-pumpkins-speak.md
+++ b/.changeset/thick-pumpkins-speak.md
@@ -1,0 +1,5 @@
+---
+'@nl-design-system-candidate/paragraph-css': major
+---
+
+Rename the mixin `nl-paragraph__b` to `nl-paragraph__lead-scss-workaround`.

--- a/.changeset/twelve-colts-melt.md
+++ b/.changeset/twelve-colts-melt.md
@@ -1,0 +1,6 @@
+---
+'@nl-design-system-candidate/paragraph-react': major
+'@nl-design-system-candidate/paragraph-css': major
+---
+
+Rename the class name `nl-paragraph__b` to `nl-paragraph__lead`.

--- a/packages/components-css/paragraph-css/src/_mixin.scss
+++ b/packages/components-css/paragraph-css/src/_mixin.scss
@@ -22,6 +22,14 @@
   line-height: var(--nl-paragraph-small-line-height, var(--nl-paragraph-line-height, inherit));
 }
 
-@mixin nl-paragraph__b {
+/*
+ * In SCSS the following mixins will overwrite each other:
+ *
+ * 1. `@mixin nl-paragraph--lead`
+ * 2. `@mixin nl-paragraph--lead`
+ *
+ * Avoid this situation by using an alternative name for this mixin.
+ */
+@mixin nl-paragraph__lead-scss-workaround {
   font-weight: inherit;
 }

--- a/packages/components-css/paragraph-css/src/_mixin.scss
+++ b/packages/components-css/paragraph-css/src/_mixin.scss
@@ -26,7 +26,7 @@
  * In SCSS the following mixins will overwrite each other:
  *
  * 1. `@mixin nl-paragraph--lead`
- * 2. `@mixin nl-paragraph--lead`
+ * 2. `@mixin nl-paragraph__lead`
  *
  * Avoid this situation by using an alternative name for this mixin.
  */

--- a/packages/components-css/paragraph-css/src/paragraph.scss
+++ b/packages/components-css/paragraph-css/src/paragraph.scss
@@ -12,6 +12,6 @@
   @include mixin.nl-paragraph--small;
 }
 
-.nl-paragraph__b {
-  @include mixin.nl-paragraph__b;
+.nl-paragraph__lead {
+  @include mixin.nl-paragraph__lead-scss-workaround;
 }

--- a/packages/components-react/paragraph-react/src/paragraph.test.tsx
+++ b/packages/components-react/paragraph-react/src/paragraph.test.tsx
@@ -111,6 +111,18 @@ describe('Paragraph', () => {
       expect(paragraph).toContainElement(b);
     });
 
+    it('renders an HTML b element that contains the contents', () => {
+      const { container } = render(
+        <Paragraph purpose="lead">
+          <span data-testid={testId}>{text}</span>
+        </Paragraph>,
+      );
+      const b = container.querySelector('b');
+      const contents = screen.getByTestId(testId);
+
+      expect(b).toContainElement(contents);
+    });
+
     it('renders a block level element', () => {
       render(<Paragraph purpose="lead">{text}</Paragraph>);
       const paragraph = screen.getByRole('paragraph');
@@ -160,13 +172,20 @@ describe('Paragraph', () => {
       expect(paragraph).toHaveClass('nl-paragraph', 'nl-paragraph--lead', extraClassName);
     });
 
-    it('renders an element with class names "nl-paragraph" and "nl-paragraph--lead" that contains an element with class name "nl-paragraph__b"', () => {
+    it('renders an HTML b element with class name "nl-paragraph__lead"', () => {
+      const { container } = render(<Paragraph purpose="lead">{text}</Paragraph>);
+      const b = container.querySelector('b');
+
+      expect(b).toHaveClass('nl-paragraph__lead');
+    });
+
+    it('renders an element with class names "nl-paragraph" and "nl-paragraph--lead" that contains an element with class name "nl-paragraph__lead"', () => {
       render(<Paragraph purpose="lead">{text}</Paragraph>);
       const paragraph = screen.getByRole('paragraph');
       const b = paragraph.querySelector(':only-child');
 
       expect(paragraph).toContainElement(b);
-      expect(b).toHaveClass('nl-paragraph__b');
+      expect(b).toHaveClass('nl-paragraph__lead');
     });
 
     it(`renders an element with text "${text}"`, () => {

--- a/packages/components-react/paragraph-react/src/paragraph.tsx
+++ b/packages/components-react/paragraph-react/src/paragraph.tsx
@@ -17,7 +17,7 @@ export const Paragraph = forwardRef<HTMLParagraphElement, ParagraphProps>(functi
       ref={forwardedRef}
       {...restProps}
     >
-      {purpose === 'lead' ? <b className="nl-paragraph__b">{children}</b> : children}
+      {purpose === 'lead' ? <b className="nl-paragraph__lead">{children}</b> : children}
     </p>
   );
 });


### PR DESCRIPTION
By the way — nu herinner ik me weer waarom de class name `__b` heette: in `scss` overschrijven de volgende mixin names elkaar:

1. `@mixin nl-paragraph--lead`
2. `@mixin nl-paragraph__lead`