### PR TITLE
feat: add Heading-x tests

### DIFF
--- a/packages/components-react/heading-1-react/package.json
+++ b/packages/components-react/heading-1-react/package.json
@@ -32,6 +32,7 @@
     "build": "rollup --config ./rollup.config.mjs",
     "clean": "rimraf ./dist/ ./*.tsbuildinfo ./.rollup.cache/",
     "test": "jest",
+    "test:watch": "jest --watch",
     "typecheck": "tsc"
   },
   "devDependencies": {

--- a/packages/components-react/heading-1-react/src/heading-1.test.tsx
+++ b/packages/components-react/heading-1-react/src/heading-1.test.tsx
@@ -1,12 +1,88 @@
+import { describe, it } from '@jest/globals';
 import '@testing-library/jest-dom';
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
+import { createRef } from 'react';
 import { Heading1 } from './heading-1';
 
-describe('Heading 1', () => {
-  it('renders a heading level 1', () => {
-    const { container } = render(<Heading1 />);
-    const heading1 = container.querySelector(':only-child');
+const extraClassName = 'extra-classname';
+const testId = 'rich-text';
+const level = 1;
 
-    expect(heading1).toBeInTheDocument();
+describe('Heading 1', () => {
+  it('renders an element with role "heading"', () => {
+    render(<Heading1 />);
+    const heading = screen.getByRole('heading');
+
+    expect(heading).toBeInTheDocument();
+  });
+
+  it(`renders a heading at level ${level}`, () => {
+    render(<Heading1 />);
+    const heading = screen.getByRole('heading', { level });
+
+    expect(heading).toBeInTheDocument();
+  });
+
+  it(`renders an HTML h${level} element`, () => {
+    const { container } = render(<Heading1 />);
+    const heading = container.querySelector(`h${level}:only-child`);
+
+    expect(heading).toBeInTheDocument();
+  });
+
+  it(`renders an element with class name "nl-heading-${level}"`, () => {
+    const { container } = render(<Heading1 />);
+    const heading = container.querySelector(`h${level}:only-child`);
+
+    expect(heading).toHaveClass(`nl-heading-${level}`);
+  });
+
+  it(`renders an element with role "heading" and name "Heading ${level}"`, () => {
+    const name = `Heading ${level}`;
+    render(<Heading1>{name}</Heading1>);
+    const heading = screen.getByRole('heading', { name });
+
+    expect(heading).toBeInTheDocument();
+  });
+
+  it(`supports hiding the HTML h${level} element visually and from the accessibility tree using the global HTML attribute "hidden"`, () => {
+    expect.assertions(2);
+    render(<Heading1 hidden />);
+    const heading = screen.getByRole('heading', { hidden: true, level });
+
+    try {
+      screen.getByRole('heading', { level });
+    } catch (e) {
+      expect(e).toBeDefined();
+    }
+    expect(heading).not.toBeVisible();
+  });
+
+  it(`renders an HTML h${level} element with an extra class name "${extraClassName}"`, () => {
+    render(<Heading1 className={extraClassName} />);
+    const heading = screen.getByRole('heading');
+
+    expect(heading).toHaveClass(`nl-heading-${level}`, extraClassName);
+  });
+
+  it('forwards React refs to the HTMLHeadingElement', () => {
+    const ref = createRef<HTMLHeadingElement>();
+    render(<Heading1 ref={ref} />);
+    const heading = screen.getByRole('heading');
+
+    expect(ref.current).toBe(heading);
+    expect(ref.current).toBeInstanceOf(HTMLHeadingElement);
+  });
+
+  it('renders rich text content', () => {
+    render(
+      <Heading1>
+        <strong data-testid={testId}>strong</strong>
+      </Heading1>,
+    );
+    const heading = screen.getByRole('heading', { level });
+    const richText = screen.getByTestId(testId);
+
+    expect(heading).toContainElement(richText);
   });
 });

--- a/packages/components-react/heading-2-react/package.json
+++ b/packages/components-react/heading-2-react/package.json
@@ -32,6 +32,7 @@
     "build": "rollup --config ./rollup.config.mjs",
     "clean": "rimraf ./dist/ ./*.tsbuildinfo ./.rollup.cache/",
     "test": "jest",
+    "test:watch": "jest --watch",
     "typecheck": "tsc"
   },
   "devDependencies": {

--- a/packages/components-react/heading-2-react/src/heading-2.test.tsx
+++ b/packages/components-react/heading-2-react/src/heading-2.test.tsx
@@ -1,12 +1,88 @@
+import { describe, it } from '@jest/globals';
 import '@testing-library/jest-dom';
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
+import { createRef } from 'react';
 import { Heading2 } from './heading-2';
 
-describe('Heading 2', () => {
-  it('renders a heading level 2', () => {
-    const { container } = render(<Heading2 />);
-    const heading2 = container.querySelector(':only-child');
+const extraClassName = 'extra-classname';
+const testId = 'rich-text';
+const level = 2;
 
-    expect(heading2).toBeInTheDocument();
+describe('Heading 2', () => {
+  it('renders an element with role "heading"', () => {
+    render(<Heading2 />);
+    const heading = screen.getByRole('heading');
+
+    expect(heading).toBeInTheDocument();
+  });
+
+  it(`renders a heading at level ${level}`, () => {
+    render(<Heading2 />);
+    const heading = screen.getByRole('heading', { level });
+
+    expect(heading).toBeInTheDocument();
+  });
+
+  it(`renders an HTML h${level} element`, () => {
+    const { container } = render(<Heading2 />);
+    const heading = container.querySelector(`h${level}:only-child`);
+
+    expect(heading).toBeInTheDocument();
+  });
+
+  it(`renders an element with class name "nl-heading-${level}"`, () => {
+    const { container } = render(<Heading2 />);
+    const heading = container.querySelector(`h${level}:only-child`);
+
+    expect(heading).toHaveClass(`nl-heading-${level}`);
+  });
+
+  it(`renders an element with role "heading" and name "Heading ${level}"`, () => {
+    const name = `Heading ${level}`;
+    render(<Heading2>{name}</Heading2>);
+    const heading = screen.getByRole('heading', { name });
+
+    expect(heading).toBeInTheDocument();
+  });
+
+  it(`supports hiding the HTML h${level} element visually and from the accessibility tree using the global HTML attribute "hidden"`, () => {
+    expect.assertions(2);
+    render(<Heading2 hidden />);
+    const heading = screen.getByRole('heading', { hidden: true, level });
+
+    try {
+      screen.getByRole('heading', { level });
+    } catch (e) {
+      expect(e).toBeDefined();
+    }
+    expect(heading).not.toBeVisible();
+  });
+
+  it(`renders an HTML h${level} element with an extra class name "${extraClassName}"`, () => {
+    render(<Heading2 className={extraClassName} />);
+    const heading = screen.getByRole('heading');
+
+    expect(heading).toHaveClass(`nl-heading-${level}`, extraClassName);
+  });
+
+  it('forwards React refs to the HTMLHeadingElement', () => {
+    const ref = createRef<HTMLHeadingElement>();
+    render(<Heading2 ref={ref} />);
+    const heading = screen.getByRole('heading');
+
+    expect(ref.current).toBe(heading);
+    expect(ref.current).toBeInstanceOf(HTMLHeadingElement);
+  });
+
+  it('renders rich text content', () => {
+    render(
+      <Heading2>
+        <strong data-testid={testId}>strong</strong>
+      </Heading2>,
+    );
+    const heading = screen.getByRole('heading', { level });
+    const richText = screen.getByTestId(testId);
+
+    expect(heading).toContainElement(richText);
   });
 });

--- a/packages/components-react/heading-2-react/src/heading-2.tsx
+++ b/packages/components-react/heading-2-react/src/heading-2.tsx
@@ -8,8 +8,8 @@ export const Heading2 = forwardRef<HTMLHeadingElement, Heading2Props>(function H
   const { children, className, ...restProps } = props;
 
   return (
-    <h1 {...restProps} className={clsx('nl-heading-2', className)} ref={forwardedRef}>
+    <h2 {...restProps} className={clsx('nl-heading-2', className)} ref={forwardedRef}>
       {children}
-    </h1>
+    </h2>
   );
 });

--- a/packages/components-react/heading-3-react/package.json
+++ b/packages/components-react/heading-3-react/package.json
@@ -32,6 +32,7 @@
     "build": "rollup --config ./rollup.config.mjs",
     "clean": "rimraf ./dist/ ./*.tsbuildinfo ./.rollup.cache/",
     "test": "jest",
+    "test:watch": "jest --watch",
     "typecheck": "tsc"
   },
   "devDependencies": {

--- a/packages/components-react/heading-3-react/src/heading-3.test.tsx
+++ b/packages/components-react/heading-3-react/src/heading-3.test.tsx
@@ -1,12 +1,88 @@
+import { describe, it } from '@jest/globals';
 import '@testing-library/jest-dom';
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
+import { createRef } from 'react';
 import { Heading3 } from './heading-3';
 
-describe('Heading 3', () => {
-  it('renders a heading level 3', () => {
-    const { container } = render(<Heading3 />);
-    const heading3 = container.querySelector(':only-child');
+const extraClassName = 'extra-classname';
+const testId = 'rich-text';
+const level = 3;
 
-    expect(heading3).toBeInTheDocument();
+describe('Heading 3', () => {
+  it('renders an element with role "heading"', () => {
+    render(<Heading3 />);
+    const heading = screen.getByRole('heading');
+
+    expect(heading).toBeInTheDocument();
+  });
+
+  it(`renders a heading at level ${level}`, () => {
+    render(<Heading3 />);
+    const heading = screen.getByRole('heading', { level });
+
+    expect(heading).toBeInTheDocument();
+  });
+
+  it(`renders an HTML h${level} element`, () => {
+    const { container } = render(<Heading3 />);
+    const heading = container.querySelector(`h${level}:only-child`);
+
+    expect(heading).toBeInTheDocument();
+  });
+
+  it(`renders an element with class name "nl-heading-${level}"`, () => {
+    const { container } = render(<Heading3 />);
+    const heading = container.querySelector(`h${level}:only-child`);
+
+    expect(heading).toHaveClass(`nl-heading-${level}`);
+  });
+
+  it(`renders an element with role "heading" and name "Heading ${level}"`, () => {
+    const name = `Heading ${level}`;
+    render(<Heading3>{name}</Heading3>);
+    const heading = screen.getByRole('heading', { name });
+
+    expect(heading).toBeInTheDocument();
+  });
+
+  it(`supports hiding the HTML h${level} element visually and from the accessibility tree using the global HTML attribute "hidden"`, () => {
+    expect.assertions(2);
+    render(<Heading3 hidden />);
+    const heading = screen.getByRole('heading', { hidden: true, level });
+
+    try {
+      screen.getByRole('heading', { level });
+    } catch (e) {
+      expect(e).toBeDefined();
+    }
+    expect(heading).not.toBeVisible();
+  });
+
+  it(`renders an HTML h${level} element with an extra class name "${extraClassName}"`, () => {
+    render(<Heading3 className={extraClassName} />);
+    const heading = screen.getByRole('heading');
+
+    expect(heading).toHaveClass(`nl-heading-${level}`, extraClassName);
+  });
+
+  it('forwards React refs to the HTMLHeadingElement', () => {
+    const ref = createRef<HTMLHeadingElement>();
+    render(<Heading3 ref={ref} />);
+    const heading = screen.getByRole('heading');
+
+    expect(ref.current).toBe(heading);
+    expect(ref.current).toBeInstanceOf(HTMLHeadingElement);
+  });
+
+  it('renders rich text content', () => {
+    render(
+      <Heading3>
+        <strong data-testid={testId}>strong</strong>
+      </Heading3>,
+    );
+    const heading = screen.getByRole('heading', { level });
+    const richText = screen.getByTestId(testId);
+
+    expect(heading).toContainElement(richText);
   });
 });

--- a/packages/components-react/heading-4-react/package.json
+++ b/packages/components-react/heading-4-react/package.json
@@ -32,6 +32,7 @@
     "build": "rollup --config ./rollup.config.mjs",
     "clean": "rimraf ./dist/ ./*.tsbuildinfo ./.rollup.cache/",
     "test": "jest",
+    "test:watch": "jest --watch",
     "typecheck": "tsc"
   },
   "devDependencies": {

--- a/packages/components-react/heading-4-react/src/heading-4.test.tsx
+++ b/packages/components-react/heading-4-react/src/heading-4.test.tsx
@@ -1,12 +1,88 @@
+import { describe, it } from '@jest/globals';
 import '@testing-library/jest-dom';
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
+import { createRef } from 'react';
 import { Heading4 } from './heading-4';
 
-describe('Heading 4', () => {
-  it('renders a heading level 4', () => {
-    const { container } = render(<Heading4 />);
-    const heading4 = container.querySelector(':only-child');
+const extraClassName = 'extra-classname';
+const testId = 'rich-text';
+const level = 4;
 
-    expect(heading4).toBeInTheDocument();
+describe('Heading 4', () => {
+  it('renders an element with role "heading"', () => {
+    render(<Heading4 />);
+    const heading = screen.getByRole('heading');
+
+    expect(heading).toBeInTheDocument();
+  });
+
+  it(`renders a heading at level ${level}`, () => {
+    render(<Heading4 />);
+    const heading = screen.getByRole('heading', { level });
+
+    expect(heading).toBeInTheDocument();
+  });
+
+  it(`renders an HTML h${level} element`, () => {
+    const { container } = render(<Heading4 />);
+    const heading = container.querySelector(`h${level}:only-child`);
+
+    expect(heading).toBeInTheDocument();
+  });
+
+  it(`renders an element with class name "nl-heading-${level}"`, () => {
+    const { container } = render(<Heading4 />);
+    const heading = container.querySelector(`h${level}:only-child`);
+
+    expect(heading).toHaveClass(`nl-heading-${level}`);
+  });
+
+  it(`renders an element with role "heading" and name "Heading ${level}"`, () => {
+    const name = `Heading ${level}`;
+    render(<Heading4>{name}</Heading4>);
+    const heading = screen.getByRole('heading', { name });
+
+    expect(heading).toBeInTheDocument();
+  });
+
+  it(`supports hiding the HTML h${level} element visually and from the accessibility tree using the global HTML attribute "hidden"`, () => {
+    expect.assertions(2);
+    render(<Heading4 hidden />);
+    const heading = screen.getByRole('heading', { hidden: true, level });
+
+    try {
+      screen.getByRole('heading', { level });
+    } catch (e) {
+      expect(e).toBeDefined();
+    }
+    expect(heading).not.toBeVisible();
+  });
+
+  it(`renders an HTML h${level} element with an extra class name "${extraClassName}"`, () => {
+    render(<Heading4 className={extraClassName} />);
+    const heading = screen.getByRole('heading');
+
+    expect(heading).toHaveClass(`nl-heading-${level}`, extraClassName);
+  });
+
+  it('forwards React refs to the HTMLHeadingElement', () => {
+    const ref = createRef<HTMLHeadingElement>();
+    render(<Heading4 ref={ref} />);
+    const heading = screen.getByRole('heading');
+
+    expect(ref.current).toBe(heading);
+    expect(ref.current).toBeInstanceOf(HTMLHeadingElement);
+  });
+
+  it('renders rich text content', () => {
+    render(
+      <Heading4>
+        <strong data-testid={testId}>strong</strong>
+      </Heading4>,
+    );
+    const heading = screen.getByRole('heading', { level });
+    const richText = screen.getByTestId(testId);
+
+    expect(heading).toContainElement(richText);
   });
 });

--- a/packages/components-react/heading-5-react/package.json
+++ b/packages/components-react/heading-5-react/package.json
@@ -32,6 +32,7 @@
     "build": "rollup --config ./rollup.config.mjs",
     "clean": "rimraf ./dist/ ./*.tsbuildinfo ./.rollup.cache/",
     "test": "jest",
+    "test:watch": "jest --watch",
     "typecheck": "tsc"
   },
   "devDependencies": {

--- a/packages/components-react/heading-5-react/src/heading-5.test.tsx
+++ b/packages/components-react/heading-5-react/src/heading-5.test.tsx
@@ -1,12 +1,88 @@
+import { describe, it } from '@jest/globals';
 import '@testing-library/jest-dom';
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
+import { createRef } from 'react';
 import { Heading5 } from './heading-5';
 
-describe('Heading 5', () => {
-  it('renders a heading level 5', () => {
-    const { container } = render(<Heading5 />);
-    const heading5 = container.querySelector(':only-child');
+const extraClassName = 'extra-classname';
+const testId = 'rich-text';
+const level = 5;
 
-    expect(heading5).toBeInTheDocument();
+describe('Heading 5', () => {
+  it('renders an element with role "heading"', () => {
+    render(<Heading5 />);
+    const heading = screen.getByRole('heading');
+
+    expect(heading).toBeInTheDocument();
+  });
+
+  it(`renders a heading at level ${level}`, () => {
+    render(<Heading5 />);
+    const heading = screen.getByRole('heading', { level });
+
+    expect(heading).toBeInTheDocument();
+  });
+
+  it(`renders an HTML h${level} element`, () => {
+    const { container } = render(<Heading5 />);
+    const heading = container.querySelector(`h${level}:only-child`);
+
+    expect(heading).toBeInTheDocument();
+  });
+
+  it(`renders an element with class name "nl-heading-${level}"`, () => {
+    const { container } = render(<Heading5 />);
+    const heading = container.querySelector(`h${level}:only-child`);
+
+    expect(heading).toHaveClass(`nl-heading-${level}`);
+  });
+
+  it(`renders an element with role "heading" and name "Heading ${level}"`, () => {
+    const name = `Heading ${level}`;
+    render(<Heading5>{name}</Heading5>);
+    const heading = screen.getByRole('heading', { name });
+
+    expect(heading).toBeInTheDocument();
+  });
+
+  it(`supports hiding the HTML h${level} element visually and from the accessibility tree using the global HTML attribute "hidden"`, () => {
+    expect.assertions(2);
+    render(<Heading5 hidden />);
+    const heading = screen.getByRole('heading', { hidden: true, level });
+
+    try {
+      screen.getByRole('heading', { level });
+    } catch (e) {
+      expect(e).toBeDefined();
+    }
+    expect(heading).not.toBeVisible();
+  });
+
+  it(`renders an HTML h${level} element with an extra class name "${extraClassName}"`, () => {
+    render(<Heading5 className={extraClassName} />);
+    const heading = screen.getByRole('heading');
+
+    expect(heading).toHaveClass(`nl-heading-${level}`, extraClassName);
+  });
+
+  it('forwards React refs to the HTMLHeadingElement', () => {
+    const ref = createRef<HTMLHeadingElement>();
+    render(<Heading5 ref={ref} />);
+    const heading = screen.getByRole('heading');
+
+    expect(ref.current).toBe(heading);
+    expect(ref.current).toBeInstanceOf(HTMLHeadingElement);
+  });
+
+  it('renders rich text content', () => {
+    render(
+      <Heading5>
+        <strong data-testid={testId}>strong</strong>
+      </Heading5>,
+    );
+    const heading = screen.getByRole('heading', { level });
+    const richText = screen.getByTestId(testId);
+
+    expect(heading).toContainElement(richText);
   });
 });

--- a/packages/components-react/heading-6-react/package.json
+++ b/packages/components-react/heading-6-react/package.json
@@ -32,6 +32,7 @@
     "build": "rollup --config ./rollup.config.mjs",
     "clean": "rimraf ./dist/ ./*.tsbuildinfo ./.rollup.cache/",
     "test": "jest",
+    "test:watch": "jest --watch",
     "typecheck": "tsc"
   },
   "devDependencies": {

--- a/packages/components-react/heading-6-react/src/heading-6.test.tsx
+++ b/packages/components-react/heading-6-react/src/heading-6.test.tsx
@@ -1,12 +1,88 @@
+import { describe, it } from '@jest/globals';
 import '@testing-library/jest-dom';
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
+import { createRef } from 'react';
 import { Heading6 } from './heading-6';
 
-describe('Heading 6', () => {
-  it('renders a heading level 6', () => {
-    const { container } = render(<Heading6 />);
-    const heading6 = container.querySelector(':only-child');
+const extraClassName = 'extra-classname';
+const testId = 'rich-text';
+const level = 6;
 
-    expect(heading6).toBeInTheDocument();
+describe('Heading 6', () => {
+  it('renders an element with role "heading"', () => {
+    render(<Heading6 />);
+    const heading = screen.getByRole('heading');
+
+    expect(heading).toBeInTheDocument();
+  });
+
+  it(`renders a heading at level ${level}`, () => {
+    render(<Heading6 />);
+    const heading = screen.getByRole('heading', { level });
+
+    expect(heading).toBeInTheDocument();
+  });
+
+  it(`renders an HTML h${level} element`, () => {
+    const { container } = render(<Heading6 />);
+    const heading = container.querySelector(`h${level}:only-child`);
+
+    expect(heading).toBeInTheDocument();
+  });
+
+  it(`renders an element with class name "nl-heading-${level}"`, () => {
+    const { container } = render(<Heading6 />);
+    const heading = container.querySelector(`h${level}:only-child`);
+
+    expect(heading).toHaveClass(`nl-heading-${level}`);
+  });
+
+  it(`renders an element with role "heading" and name "Heading ${level}"`, () => {
+    const name = `Heading ${level}`;
+    render(<Heading6>{name}</Heading6>);
+    const heading = screen.getByRole('heading', { name });
+
+    expect(heading).toBeInTheDocument();
+  });
+
+  it(`supports hiding the HTML h${level} element visually and from the accessibility tree using the global HTML attribute "hidden"`, () => {
+    expect.assertions(2);
+    render(<Heading6 hidden />);
+    const heading = screen.getByRole('heading', { hidden: true, level });
+
+    try {
+      screen.getByRole('heading', { level });
+    } catch (e) {
+      expect(e).toBeDefined();
+    }
+    expect(heading).not.toBeVisible();
+  });
+
+  it(`renders an HTML h${level} element with an extra class name "${extraClassName}"`, () => {
+    render(<Heading6 className={extraClassName} />);
+    const heading = screen.getByRole('heading');
+
+    expect(heading).toHaveClass(`nl-heading-${level}`, extraClassName);
+  });
+
+  it('forwards React refs to the HTMLHeadingElement', () => {
+    const ref = createRef<HTMLHeadingElement>();
+    render(<Heading6 ref={ref} />);
+    const heading = screen.getByRole('heading');
+
+    expect(ref.current).toBe(heading);
+    expect(ref.current).toBeInstanceOf(HTMLHeadingElement);
+  });
+
+  it('renders rich text content', () => {
+    render(
+      <Heading6>
+        <strong data-testid={testId}>strong</strong>
+      </Heading6>,
+    );
+    const heading = screen.getByRole('heading', { level });
+    const richText = screen.getByTestId(testId);
+
+    expect(heading).toContainElement(richText);
   });
 });


### PR DESCRIPTION
- Fix: Heading2 was rendering a h1
- Add all useful tests for heading-react -> heading-x-react