### PR TITLE
chore: remove @types/jest

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
     "@testing-library/dom": "10.4.0",
     "@testing-library/jest-dom": "6.6.3",
     "@testing-library/react": "16.0.1",
-    "@types/jest": "29.5.14",
     "@types/node": "20.17.6",
     "eslint": "9.14.0",
     "husky": "9.1.6",

--- a/packages/components-react/code-block-react/src/code-block.test.tsx
+++ b/packages/components-react/code-block-react/src/code-block.test.tsx
@@ -1,4 +1,5 @@
-import '@testing-library/jest-dom';
+import { describe, expect, it } from '@jest/globals';
+import '@testing-library/jest-dom/jest-globals';
 import { render } from '@testing-library/react';
 import { CodeBlock } from './code-block';
 

--- a/packages/components-react/code-react/src/code.test.tsx
+++ b/packages/components-react/code-react/src/code.test.tsx
@@ -1,4 +1,5 @@
-import '@testing-library/jest-dom';
+import { describe, expect, it } from '@jest/globals';
+import '@testing-library/jest-dom/jest-globals';
 import { render } from '@testing-library/react';
 import { Code } from './code';
 

--- a/packages/components-react/color-sample-react/src/color-sample.test.tsx
+++ b/packages/components-react/color-sample-react/src/color-sample.test.tsx
@@ -1,5 +1,5 @@
-import { describe, it } from '@jest/globals';
-import '@testing-library/jest-dom';
+import { describe, expect, it } from '@jest/globals';
+import '@testing-library/jest-dom/jest-globals';
 import { render, screen } from '@testing-library/react';
 import { createRef } from 'react';
 import { ColorSample } from './color-sample';

--- a/packages/components-react/heading-react/src/heading.test.tsx
+++ b/packages/components-react/heading-react/src/heading.test.tsx
@@ -1,5 +1,5 @@
-import { describe, it } from '@jest/globals';
-import '@testing-library/jest-dom';
+import { describe, expect, it } from '@jest/globals';
+import '@testing-library/jest-dom/jest-globals';
 import { render, screen } from '@testing-library/react';
 import { createRef } from 'react';
 import type { HeadingAppearance } from './heading';

--- a/packages/components-react/link-react/src/link.test.tsx
+++ b/packages/components-react/link-react/src/link.test.tsx
@@ -1,4 +1,5 @@
-import '@testing-library/jest-dom';
+import { describe, expect, it } from '@jest/globals';
+import '@testing-library/jest-dom/jest-globals';
 import { render } from '@testing-library/react';
 import { Link } from './link';
 

--- a/packages/components-react/mark-react/src/mark.test.tsx
+++ b/packages/components-react/mark-react/src/mark.test.tsx
@@ -1,4 +1,5 @@
-import '@testing-library/jest-dom';
+import { describe, expect, it } from '@jest/globals';
+import '@testing-library/jest-dom/jest-globals';
 import { render } from '@testing-library/react';
 import { Mark } from './mark';
 

--- a/packages/components-react/paragraph-react/src/paragraph.test.tsx
+++ b/packages/components-react/paragraph-react/src/paragraph.test.tsx
@@ -1,5 +1,5 @@
-import { describe, it } from '@jest/globals';
-import '@testing-library/jest-dom';
+import { describe, expect, it } from '@jest/globals';
+import '@testing-library/jest-dom/jest-globals';
 import { render, screen } from '@testing-library/react';
 import { createRef } from 'react';
 import { Paragraph } from './paragraph';

--- a/packages/components-react/skip-link-react/src/skip-link.test.tsx
+++ b/packages/components-react/skip-link-react/src/skip-link.test.tsx
@@ -1,4 +1,5 @@
-import '@testing-library/jest-dom';
+import { describe, expect, it } from '@jest/globals';
+import '@testing-library/jest-dom/jest-globals';
 import { render, screen } from '@testing-library/react';
 import { createRef } from 'react';
 import { SkipLink } from './skip-link';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,7 +38,7 @@ importers:
         version: 0.0.1(eslint@9.14.0)(typescript@5.6.3)
       '@nl-design-system/rollup-config-react-component':
         specifier: 1.0.3
-        version: 1.0.3(@types/babel__core@7.20.5)(postcss@8.4.47)(rollup@4.25.0)(tslib@2.6.3)(typescript@5.6.3)
+        version: 1.0.3(@types/babel__core@7.20.5)(postcss@8.4.47)(rollup@4.25.0)(typescript@5.6.3)
       '@nl-design-system/tsconfig':
         specifier: 1.0.1
         version: 1.0.1(typescript@5.6.3)
@@ -50,10 +50,7 @@ importers:
         version: 6.6.3
       '@testing-library/react':
         specifier: 16.0.1
-        version: 16.0.1(@testing-library/dom@10.4.0)(@types/react-dom@18.3.1)(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@types/jest':
-        specifier: 29.5.14
-        version: 29.5.14
+        version: 16.0.1(@testing-library/dom@10.4.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@types/node':
         specifier: 20.17.6
         version: 20.17.6
@@ -2129,9 +2126,6 @@ packages:
 
   '@types/istanbul-reports@3.0.4':
     resolution: {integrity: sha512-pk2B1NWalF9toCRu6gjBzR69syFjP4Od8WRAX+0mmf9lAjCRicLOWc+ZrxZHx/0XRjotgkF9t6iaMJ+aXcOdZQ==}
-
-  '@types/jest@29.5.14':
-    resolution: {integrity: sha512-ZN+4sdnLUbo8EVvVc2ao0GFW6oVrQRPn4K2lglySj7APvSrgzxHiNNK99us4WDMi57xxA2yggblIAMNhXOotLQ==}
 
   '@types/jsdom@20.0.1':
     resolution: {integrity: sha512-d0r18sZPmMQr1eG35u12FZfhIXNrnsPU/g5wvRKCUf/tOGilKKwYMYGqh33BNR6ba+2gkHw1EUiHoN3mn7E5IQ==}
@@ -7254,12 +7248,12 @@ snapshots:
       - typescript
       - vue-eslint-parser
 
-  '@nl-design-system/rollup-config-react-component@1.0.3(@types/babel__core@7.20.5)(postcss@8.4.47)(rollup@4.25.0)(tslib@2.6.3)(typescript@5.6.3)':
+  '@nl-design-system/rollup-config-react-component@1.0.3(@types/babel__core@7.20.5)(postcss@8.4.47)(rollup@4.25.0)(typescript@5.6.3)':
     dependencies:
       '@babel/core': 7.26.0
       '@rollup/plugin-babel': 6.0.4(@babel/core@7.26.0)(@types/babel__core@7.20.5)(rollup@4.25.0)
       '@rollup/plugin-node-resolve': 15.3.0(rollup@4.25.0)
-      '@rollup/plugin-typescript': 12.1.1(rollup@4.25.0)(tslib@2.6.3)(typescript@5.6.3)
+      '@rollup/plugin-typescript': 12.1.1(rollup@4.25.0)(typescript@5.6.3)
       rollup: 4.25.0
       rollup-plugin-node-externals: 7.1.3(rollup@4.25.0)
       rollup-plugin-peer-deps-external: 2.2.4(rollup@4.25.0)
@@ -7369,14 +7363,13 @@ snapshots:
     optionalDependencies:
       rollup: 4.25.0
 
-  '@rollup/plugin-typescript@12.1.1(rollup@4.25.0)(tslib@2.6.3)(typescript@5.6.3)':
+  '@rollup/plugin-typescript@12.1.1(rollup@4.25.0)(typescript@5.6.3)':
     dependencies:
       '@rollup/pluginutils': 5.1.2(rollup@4.25.0)
       resolve: 1.22.8
       typescript: 5.6.3
     optionalDependencies:
       rollup: 4.25.0
-      tslib: 2.6.3
 
   '@rollup/pluginutils@5.1.2(rollup@4.25.0)':
     dependencies:
@@ -7667,15 +7660,12 @@ snapshots:
       lodash: 4.17.21
       redent: 3.0.0
 
-  '@testing-library/react@16.0.1(@testing-library/dom@10.4.0)(@types/react-dom@18.3.1)(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@testing-library/react@16.0.1(@testing-library/dom@10.4.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@babel/runtime': 7.26.0
       '@testing-library/dom': 10.4.0
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-    optionalDependencies:
-      '@types/react': 18.3.12
-      '@types/react-dom': 18.3.1
 
   '@testing-library/user-event@14.5.2(@testing-library/dom@10.4.0)':
     dependencies:
@@ -7734,11 +7724,6 @@ snapshots:
   '@types/istanbul-reports@3.0.4':
     dependencies:
       '@types/istanbul-lib-report': 3.0.3
-
-  '@types/jest@29.5.14':
-    dependencies:
-      expect: 29.7.0
-      pretty-format: 29.7.0
 
   '@types/jsdom@20.0.1':
     dependencies:


### PR DESCRIPTION
Explicitly import `describe`, `expect`, and `it` from `@jest/globals` and run the side effect from `@testing-library/jest-dom/jest-globals`:

```js
import {expect} from '@jest/globals'
import * as extensions from './matchers'

expect.extend(extensions)
```