### PR TITLE
chore: add missing package entries

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -542,6 +542,10 @@ importers:
 
   packages/tokens/code-tokens: {}
 
+  packages/tokens/data-badge-tokens: {}
+
+  packages/tokens/link-tokens: {}
+
   packages/tokens/mark-tokens: {}
 
   packages/tokens/paragraph-tokens: {}


### PR DESCRIPTION
Add missing package entries in pnpm-lock.yaml