### PR TITLE
fix: align paragraph-css with paragraph-tokens

### DIFF
--- a/packages/components-css/paragraph-css/src/_mixin.scss
+++ b/packages/components-css/paragraph-css/src/_mixin.scss
@@ -4,22 +4,12 @@
   font-size: var(--nl-paragraph-font-size, inherit);
   font-weight: var(--nl-paragraph-font-weight, inherit);
   line-height: var(--nl-paragraph-line-height, inherit);
-  margin-block-end: calc(var(--nl-space-around, 0) * var(--nl-paragraph-margin-block-end, 0));
-  margin-block-start: calc(var(--nl-space-around, 0) * var(--nl-paragraph-margin-block-start, 0));
 }
 
 @mixin nl-paragraph--lead {
-  color: var(--nl-paragraph-lead-color, var(--nl-paragraph-color, inherit));
   font-size: var(--nl-paragraph-lead-font-size, var(--nl-paragraph-font-size, inherit));
   font-weight: var(--nl-paragraph-lead-font-weight, var(--nl-paragraph-font-weight, inherit));
   line-height: var(--nl-paragraph-lead-line-height, var(--nl-paragraph-line-height, inherit));
-}
-
-@mixin nl-paragraph--small {
-  color: var(--nl-paragraph-small-color, var(--nl-paragraph-color, inherit));
-  font-size: var(--nl-paragraph-small-font-size, var(--nl-paragraph-font-size, inherit));
-  font-weight: var(--nl-paragraph-small-font-weight, var(--nl-paragraph-font-weight, inherit));
-  line-height: var(--nl-paragraph-small-line-height, var(--nl-paragraph-line-height, inherit));
 }
 
 /*

--- a/packages/components-css/paragraph-css/src/paragraph.scss
+++ b/packages/components-css/paragraph-css/src/paragraph.scss
@@ -8,10 +8,6 @@
   @include mixin.nl-paragraph--lead;
 }
 
-.nl-paragraph--small {
-  @include mixin.nl-paragraph--small;
-}
-
 .nl-paragraph__lead {
   @include mixin.nl-paragraph__lead-scss-workaround;
 }


### PR DESCRIPTION
Remove CSS custom properties from paragraph-css that were not based on tokens from paragraph-tokens