### PR TITLE
fix: paragraph-docs version

### DIFF
--- a/packages/docs/paragraph-docs/package.json
+++ b/packages/docs/paragraph-docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nl-design-system-candidate/paragraph-docs",
-  "version": "1.0.0",
+  "version": "0.0.0",
   "description": "Documentatie voor het Paragraph component",
   "license": "CC0-1.0",
   "homepage": "https://github.com/nl-design-system/candidate/tree/main/packages/docs/paragraph-docs#readme",


### PR DESCRIPTION
Reset the version of paragraph-docs back to 0.0.0 to see if changeset is going to suggest 1.0.0 as the new major version instead of 2.0.0 when it has not ever been published.