### PR TITLE
chore: add coverage

### DIFF
--- a/packages/components-react/code-block-react/jest.config.mjs
+++ b/packages/components-react/code-block-react/jest.config.mjs
@@ -2,5 +2,6 @@
  * @type {import('jest').Config}
  * */
 export default {
+  coverageProvider: 'v8',
   testEnvironment: 'jest-environment-jsdom',
 };

--- a/packages/components-react/code-block-react/package.json
+++ b/packages/components-react/code-block-react/package.json
@@ -30,8 +30,9 @@
   },
   "scripts": {
     "build": "rollup --config ./rollup.config.mjs",
-    "clean": "rimraf ./dist/ ./*.tsbuildinfo ./.rollup.cache/",
+    "clean": "rimraf ./dist/ ./*.tsbuildinfo ./.rollup.cache/ ./coverage/",
     "test": "jest",
+    "test:coverage": "jest --coverage",
     "test:watch": "jest --watch",
     "typecheck": "tsc"
   },

--- a/packages/components-react/code-react/jest.config.mjs
+++ b/packages/components-react/code-react/jest.config.mjs
@@ -2,5 +2,6 @@
  * @type {import('jest').Config}
  * */
 export default {
+  coverageProvider: 'v8',
   testEnvironment: 'jest-environment-jsdom',
 };

--- a/packages/components-react/code-react/package.json
+++ b/packages/components-react/code-react/package.json
@@ -30,8 +30,9 @@
   },
   "scripts": {
     "build": "rollup --config ./rollup.config.mjs",
-    "clean": "rimraf ./dist/ ./*.tsbuildinfo ./.rollup.cache/",
+    "clean": "rimraf ./dist/ ./*.tsbuildinfo ./.rollup.cache/ ./coverage/",
     "test": "jest",
+    "test:coverage": "jest --coverage",
     "test:watch": "jest --watch",
     "typecheck": "tsc"
   },

--- a/packages/components-react/color-sample-react/jest.config.mjs
+++ b/packages/components-react/color-sample-react/jest.config.mjs
@@ -2,5 +2,6 @@
  * @type {import('jest').Config}
  * */
 export default {
+  coverageProvider: 'v8',
   testEnvironment: 'jest-environment-jsdom',
 };

--- a/packages/components-react/color-sample-react/package.json
+++ b/packages/components-react/color-sample-react/package.json
@@ -30,8 +30,9 @@
   },
   "scripts": {
     "build": "rollup --config ./rollup.config.mjs",
-    "clean": "rimraf ./dist/ ./*.tsbuildinfo ./.rollup.cache/",
+    "clean": "rimraf ./dist/ ./*.tsbuildinfo ./.rollup.cache/ ./coverage/",
     "test": "jest",
+    "test:coverage": "jest --coverage",
     "test:watch": "jest --watch",
     "typecheck": "tsc"
   },

--- a/packages/components-react/data-badge-react/jest.config.mjs
+++ b/packages/components-react/data-badge-react/jest.config.mjs
@@ -2,5 +2,6 @@
  * @type {import('jest').Config}
  * */
 export default {
+  coverageProvider: 'v8',
   testEnvironment: 'jest-environment-jsdom',
 };

--- a/packages/components-react/data-badge-react/package.json
+++ b/packages/components-react/data-badge-react/package.json
@@ -30,8 +30,9 @@
   },
   "scripts": {
     "build": "rollup --config ./rollup.config.mjs",
-    "clean": "rimraf ./dist/ ./*.tsbuildinfo ./.rollup.cache/",
+    "clean": "rimraf ./dist/ ./*.tsbuildinfo ./.rollup.cache/ ./coverage/",
     "test": "jest",
+    "test:coverage": "jest --coverage",
     "test:watch": "jest --watch",
     "typecheck": "tsc"
   },

--- a/packages/components-react/heading-1-react/jest.config.mjs
+++ b/packages/components-react/heading-1-react/jest.config.mjs
@@ -2,5 +2,6 @@
  * @type {import('jest').Config}
  * */
 export default {
+  coverageProvider: 'v8',
   testEnvironment: 'jest-environment-jsdom',
 };

--- a/packages/components-react/heading-1-react/package.json
+++ b/packages/components-react/heading-1-react/package.json
@@ -30,8 +30,9 @@
   },
   "scripts": {
     "build": "rollup --config ./rollup.config.mjs",
-    "clean": "rimraf ./dist/ ./*.tsbuildinfo ./.rollup.cache/",
+    "clean": "rimraf ./dist/ ./*.tsbuildinfo ./.rollup.cache/ ./coverage/",
     "test": "jest",
+    "test:coverage": "jest --coverage",
     "test:watch": "jest --watch",
     "typecheck": "tsc"
   },

--- a/packages/components-react/heading-2-react/jest.config.mjs
+++ b/packages/components-react/heading-2-react/jest.config.mjs
@@ -2,5 +2,6 @@
  * @type {import('jest').Config}
  * */
 export default {
+  coverageProvider: 'v8',
   testEnvironment: 'jest-environment-jsdom',
 };

--- a/packages/components-react/heading-2-react/package.json
+++ b/packages/components-react/heading-2-react/package.json
@@ -30,8 +30,9 @@
   },
   "scripts": {
     "build": "rollup --config ./rollup.config.mjs",
-    "clean": "rimraf ./dist/ ./*.tsbuildinfo ./.rollup.cache/",
+    "clean": "rimraf ./dist/ ./*.tsbuildinfo ./.rollup.cache/ ./coverage/",
     "test": "jest",
+    "test:coverage": "jest --coverage",
     "test:watch": "jest --watch",
     "typecheck": "tsc"
   },

--- a/packages/components-react/heading-3-react/jest.config.mjs
+++ b/packages/components-react/heading-3-react/jest.config.mjs
@@ -2,5 +2,6 @@
  * @type {import('jest').Config}
  * */
 export default {
+  coverageProvider: 'v8',
   testEnvironment: 'jest-environment-jsdom',
 };

--- a/packages/components-react/heading-3-react/package.json
+++ b/packages/components-react/heading-3-react/package.json
@@ -30,8 +30,9 @@
   },
   "scripts": {
     "build": "rollup --config ./rollup.config.mjs",
-    "clean": "rimraf ./dist/ ./*.tsbuildinfo ./.rollup.cache/",
+    "clean": "rimraf ./dist/ ./*.tsbuildinfo ./.rollup.cache/ ./coverage/",
     "test": "jest",
+    "test:coverage": "jest --coverage",
     "test:watch": "jest --watch",
     "typecheck": "tsc"
   },

--- a/packages/components-react/heading-4-react/jest.config.mjs
+++ b/packages/components-react/heading-4-react/jest.config.mjs
@@ -2,5 +2,6 @@
  * @type {import('jest').Config}
  * */
 export default {
+  coverageProvider: 'v8',
   testEnvironment: 'jest-environment-jsdom',
 };

--- a/packages/components-react/heading-4-react/package.json
+++ b/packages/components-react/heading-4-react/package.json
@@ -30,8 +30,9 @@
   },
   "scripts": {
     "build": "rollup --config ./rollup.config.mjs",
-    "clean": "rimraf ./dist/ ./*.tsbuildinfo ./.rollup.cache/",
+    "clean": "rimraf ./dist/ ./*.tsbuildinfo ./.rollup.cache/ ./coverage/",
     "test": "jest",
+    "test:coverage": "jest --coverage",
     "test:watch": "jest --watch",
     "typecheck": "tsc"
   },

--- a/packages/components-react/heading-5-react/jest.config.mjs
+++ b/packages/components-react/heading-5-react/jest.config.mjs
@@ -2,5 +2,6 @@
  * @type {import('jest').Config}
  * */
 export default {
+  coverageProvider: 'v8',
   testEnvironment: 'jest-environment-jsdom',
 };

--- a/packages/components-react/heading-5-react/package.json
+++ b/packages/components-react/heading-5-react/package.json
@@ -30,8 +30,9 @@
   },
   "scripts": {
     "build": "rollup --config ./rollup.config.mjs",
-    "clean": "rimraf ./dist/ ./*.tsbuildinfo ./.rollup.cache/",
+    "clean": "rimraf ./dist/ ./*.tsbuildinfo ./.rollup.cache/ ./coverage/",
     "test": "jest",
+    "test:coverage": "jest --coverage",
     "test:watch": "jest --watch",
     "typecheck": "tsc"
   },

--- a/packages/components-react/heading-6-react/jest.config.mjs
+++ b/packages/components-react/heading-6-react/jest.config.mjs
@@ -2,5 +2,6 @@
  * @type {import('jest').Config}
  * */
 export default {
+  coverageProvider: 'v8',
   testEnvironment: 'jest-environment-jsdom',
 };

--- a/packages/components-react/heading-6-react/package.json
+++ b/packages/components-react/heading-6-react/package.json
@@ -30,8 +30,9 @@
   },
   "scripts": {
     "build": "rollup --config ./rollup.config.mjs",
-    "clean": "rimraf ./dist/ ./*.tsbuildinfo ./.rollup.cache/",
+    "clean": "rimraf ./dist/ ./*.tsbuildinfo ./.rollup.cache/ ./coverage/",
     "test": "jest",
+    "test:coverage": "jest --coverage",
     "test:watch": "jest --watch",
     "typecheck": "tsc"
   },

--- a/packages/components-react/heading-react/jest.config.mjs
+++ b/packages/components-react/heading-react/jest.config.mjs
@@ -2,5 +2,6 @@
  * @type {import('jest').Config}
  * */
 export default {
+  coverageProvider: 'v8',
   testEnvironment: 'jest-environment-jsdom',
 };

--- a/packages/components-react/heading-react/package.json
+++ b/packages/components-react/heading-react/package.json
@@ -30,8 +30,9 @@
   },
   "scripts": {
     "build": "rollup --config ./rollup.config.mjs",
-    "clean": "rimraf ./dist/ ./*.tsbuildinfo ./.rollup.cache/",
+    "clean": "rimraf ./dist/ ./*.tsbuildinfo ./.rollup.cache/ ./coverage/",
     "test": "jest",
+    "test:coverage": "jest --coverage",
     "test:watch": "jest --watch",
     "typecheck": "tsc"
   },

--- a/packages/components-react/link-react/jest.config.mjs
+++ b/packages/components-react/link-react/jest.config.mjs
@@ -2,5 +2,6 @@
  * @type {import('jest').Config}
  * */
 export default {
+  coverageProvider: 'v8',
   testEnvironment: 'jest-environment-jsdom',
 };

--- a/packages/components-react/link-react/package.json
+++ b/packages/components-react/link-react/package.json
@@ -30,8 +30,9 @@
   },
   "scripts": {
     "build": "rollup --config ./rollup.config.mjs",
-    "clean": "rimraf ./dist/ ./*.tsbuildinfo ./.rollup.cache/",
+    "clean": "rimraf ./dist/ ./*.tsbuildinfo ./.rollup.cache/ ./coverage/",
     "test": "jest",
+    "test:coverage": "jest --coverage",
     "test:watch": "jest --watch",
     "typecheck": "tsc"
   },

--- a/packages/components-react/mark-react/jest.config.mjs
+++ b/packages/components-react/mark-react/jest.config.mjs
@@ -2,5 +2,6 @@
  * @type {import('jest').Config}
  * */
 export default {
+  coverageProvider: 'v8',
   testEnvironment: 'jest-environment-jsdom',
 };

--- a/packages/components-react/mark-react/package.json
+++ b/packages/components-react/mark-react/package.json
@@ -30,8 +30,9 @@
   },
   "scripts": {
     "build": "rollup --config ./rollup.config.mjs",
-    "clean": "rimraf ./dist/ ./*.tsbuildinfo ./.rollup.cache/",
+    "clean": "rimraf ./dist/ ./*.tsbuildinfo ./.rollup.cache/ ./coverage/",
     "test": "jest",
+    "test:coverage": "jest --coverage",
     "test:watch": "jest --watch",
     "typecheck": "tsc"
   },

--- a/packages/components-react/number-badge-react/jest.config.mjs
+++ b/packages/components-react/number-badge-react/jest.config.mjs
@@ -2,5 +2,6 @@
  * @type {import('jest').Config}
  * */
 export default {
+  coverageProvider: 'v8',
   testEnvironment: 'jest-environment-jsdom',
 };

--- a/packages/components-react/number-badge-react/package.json
+++ b/packages/components-react/number-badge-react/package.json
@@ -30,8 +30,9 @@
   },
   "scripts": {
     "build": "rollup --config ./rollup.config.mjs",
-    "clean": "rimraf ./dist/ ./*.tsbuildinfo ./.rollup.cache/",
+    "clean": "rimraf ./dist/ ./*.tsbuildinfo ./.rollup.cache/ ./coverage/",
     "test": "jest",
+    "test:coverage": "jest --coverage",
     "test:watch": "jest --watch",
     "typecheck": "tsc"
   },

--- a/packages/components-react/paragraph-react/jest.config.mjs
+++ b/packages/components-react/paragraph-react/jest.config.mjs
@@ -2,5 +2,6 @@
  * @type {import('jest').Config}
  * */
 export default {
+  coverageProvider: 'v8',
   testEnvironment: 'jest-environment-jsdom',
 };

--- a/packages/components-react/paragraph-react/package.json
+++ b/packages/components-react/paragraph-react/package.json
@@ -29,8 +29,9 @@
   },
   "scripts": {
     "build": "rollup --config ./rollup.config.mjs",
-    "clean": "rimraf ./dist/ ./*.tsbuildinfo ./.rollup.cache/",
+    "clean": "rimraf ./dist/ ./*.tsbuildinfo ./.rollup.cache/ ./coverage/",
     "test": "jest",
+    "test:coverage": "jest --coverage",
     "test:watch": "jest --watch",
     "typecheck": "tsc"
   },

--- a/packages/components-react/skip-link-react/jest.config.mjs
+++ b/packages/components-react/skip-link-react/jest.config.mjs
@@ -2,5 +2,6 @@
  * @type {import('jest').Config}
  * */
 export default {
+  coverageProvider: 'v8',
   testEnvironment: 'jest-environment-jsdom',
 };

--- a/packages/components-react/skip-link-react/package.json
+++ b/packages/components-react/skip-link-react/package.json
@@ -30,8 +30,9 @@
   },
   "scripts": {
     "build": "rollup --config ./rollup.config.mjs",
-    "clean": "rimraf ./dist/ ./*.tsbuildinfo ./.rollup.cache/",
+    "clean": "rimraf ./dist/ ./*.tsbuildinfo ./.rollup.cache/ ./coverage/",
     "test": "jest",
+    "test:coverage": "jest --coverage",
     "test:watch": "jest --watch",
     "typecheck": "tsc"
   },


### PR DESCRIPTION
Add a coverageProvider to the Jest configurations
Add a new script `test:coverage`
Make sure `./coverage` is removed by running the clean script