### PR TITLE
chore: rename "start" -> "storybook"

### DIFF
--- a/packages/storybook-test/package.json
+++ b/packages/storybook-test/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "build": "storybook build --config-dir ./config/ --output-dir ./dist/",
     "clean": "rimraf ./dist/",
-    "start": "storybook dev --config-dir ./config/ --port 6007"
+    "storybook": "storybook dev --config-dir ./config/ --port 6007"
   },
   "private": true,
   "repository": {

--- a/packages/storybook/package.json
+++ b/packages/storybook/package.json
@@ -16,7 +16,7 @@
   "scripts": {
     "build": "storybook build --config-dir ./config/ --output-dir ./dist/",
     "clean": "rimraf ./dist/",
-    "start": "storybook dev --config-dir ./config/ --port 6006"
+    "storybook": "storybook dev --config-dir ./config/ --port 6006"
   },
   "devDependencies": {
     "@etchteam/storybook-addon-status": "5.0.0",


### PR DESCRIPTION
The new command to run Storybook is:

`pnpm run storybook`

when run from inside `./packages/storybook` or
`./packages/storybook-test`

Or:

`pnpm --filter @nl-design-system-candidate/storybook run storybook`

When run from anywhere in the repository