### PR TITLE
fix: rename I18n -> I18nDecorator

### DIFF
--- a/packages/storybook-test/src/I18nDecorator.tsx
+++ b/packages/storybook-test/src/I18nDecorator.tsx
@@ -8,7 +8,7 @@ i18n.on('languageChanged', function changeDocumentDirection(locale) {
   document.documentElement.lang = locale;
 });
 
-export const I18n: Decorator = (Story, context) => {
+export const I18nDecorator: Decorator = (Story, context) => {
   const { locale } = context.globals;
 
   useEffect(() => {

--- a/packages/storybook-test/stories/heading.stories.tsx
+++ b/packages/storybook-test/stories/heading.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react';
 import { useTranslation } from 'react-i18next';
 import packageJSON from '../../components-react/heading-react/package.json';
 import { Heading } from '../../components-react/heading-react/src/css';
-import { I18n } from '../src/I18n';
+import { I18nDecorator } from '../src/I18nDecorator';
 
 const meta = {
   argTypes: {
@@ -76,7 +76,7 @@ export const HeadingLevel1Arabic: Story = {
     children: 'voorbeeld',
     level: 1,
   },
-  decorators: [I18n],
+  decorators: [I18nDecorator],
   globals: {
     locale: 'ar',
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -633,6 +633,8 @@ importers:
 
   packages/tokens/data-badge-tokens: {}
 
+  packages/tokens/heading-tokens: {}
+
   packages/tokens/link-tokens: {}
 
   packages/tokens/mark-tokens: {}


### PR DESCRIPTION
Because there is no difference between `i18n.ts` and `I18n.tsx` on systems without case sensitive file names the decorator was renamed to `I18nDecorator` with a file name accordingly