### PR TITLE
chore: extend Stylelint ignore

### DIFF
--- a/stylelint.config.mjs
+++ b/stylelint.config.mjs
@@ -1,6 +1,6 @@
 export default {
   extends: ['stylelint-config-standard-scss'],
-  ignoreFiles: ['node_modules', '**/dist/**/*'],
+  ignoreFiles: ['node_modules', '**/dist/**/*', '**/coverage/**/*'],
   plugins: ['stylelint-order'],
   rules: {
     'alpha-value-notation': ['percentage'],


### PR DESCRIPTION
The HTML coverage files that Jest writes in a package's `coverage/` folder contains CSS that should be ignored by Stylelint.