### PR TITLE
chore: add Vite configs to Storybooks

### DIFF
--- a/packages/storybook-test/vite.config.mjs
+++ b/packages/storybook-test/vite.config.mjs
@@ -1,0 +1,12 @@
+import { defineConfig } from 'vite';
+
+export default defineConfig({
+  css: {
+    preprocessorOptions: {
+      scss: {
+        // Make sure the modern Dart Sass API is used
+        api: 'modern',
+      },
+    },
+  },
+});

--- a/packages/storybook/vite.config.mjs
+++ b/packages/storybook/vite.config.mjs
@@ -1,0 +1,12 @@
+import { defineConfig } from 'vite';
+
+export default defineConfig({
+  css: {
+    preprocessorOptions: {
+      scss: {
+        // Make sure the modern Dart Sass API is used
+        api: 'modern',
+      },
+    },
+  },
+});


### PR DESCRIPTION
By default Storybook's Vite configuration uses the legacy Dart Sass API that is deprecated now and will be removed in Dart Sass 2.0.0

Adding a Vite configuration makes sure that the modern Dart Sass API is used instead