### PR TITLE
Update exports (paragraph + number badge) & toegang (number badge)

### DIFF
--- a/.changeset/verander-maar.md
+++ b/.changeset/verander-maar.md
@@ -1,0 +1,7 @@
+---
+'@nl-design-system-candidate/number-badge-docs': patch
+'@nl-design-system-candidate/paragraph-docs': patch
+---
+
+- Maak “number badge” docs publiek beschikbaar
+- Gebruik bij “paragraph” docs en “number badge” docs de default exports. 

--- a/.changeset/verander-maar.md
+++ b/.changeset/verander-maar.md
@@ -1,7 +1,7 @@
 ---
-'@nl-design-system-candidate/number-badge-docs': patch
-'@nl-design-system-candidate/paragraph-docs': patch
+"@nl-design-system-candidate/number-badge-docs": major
+"@nl-design-system-candidate/paragraph-docs": patch
 ---
 
 - Maak “number badge” docs publiek beschikbaar
-- Gebruik bij “paragraph” docs en “number badge” docs de default exports. 
+- Gebruik bij “paragraph” docs en “number badge” docs de default exports.

--- a/.changeset/verander-maar.md
+++ b/.changeset/verander-maar.md
@@ -1,7 +1,0 @@
----
-"@nl-design-system-candidate/number-badge-docs": major
-"@nl-design-system-candidate/paragraph-docs": patch
----
-
-- Maak “number badge” docs publiek beschikbaar
-- Gebruik bij “paragraph” docs en “number badge” docs de default exports.

--- a/packages/docs/number-badge-docs/package.json
+++ b/packages/docs/number-badge-docs/package.json
@@ -13,14 +13,10 @@
   "files": [
     "./docs/"
   ],
-  "exports": {
-    "./*.md": "./docs/*.md"
-  },
   "repository": {
     "type": "git+ssh",
     "directory": "packages/docs/number-badge-docs"
   },
-  "private": true,
   "publishConfig": {
     "access": "public"
   }

--- a/packages/docs/paragraph-docs/package.json
+++ b/packages/docs/paragraph-docs/package.json
@@ -13,9 +13,6 @@
   "files": [
     "./docs/"
   ],
-  "exports": {
-    "./*.md": "./docs/*.md"
-  },
   "repository": {
     "type": "git+ssh",
     "url": "git@github.com:nl-design-system/candidate.git",


### PR DESCRIPTION
## Number badge publiek

De number badge was nog niet publiek beschikbaar.

## Exports property 

Voor paragraph en number badge was er in de `package.json` een `exports` property die niet bij andere docs gebruikt werd. 

De packages zonder `exports` heb ik geïmporteerd in de documentatiesite, bij die mèt expliciet `exports` kreeg ik een foutmelding over een niet-kloppend pad, bij de rest niet. 

Waarschijnlijk kan dit ook opgelost worden door een ander pad te gebruiken in de documentatiesite, maar in dat geval zou het netjes zijn om de andere packages een zelfde expliciete exports mee te geven? Ik heb geen voorkeur over wat mooier is.