### PR TITLE
docs: log a11y test findings with links to NL Design System

### DIFF
--- a/packages/storybook-shared/src/StoryRootDecorator.tsx
+++ b/packages/storybook-shared/src/StoryRootDecorator.tsx
@@ -1,10 +1,34 @@
 import type { Decorator } from '@storybook/react';
-import type { CSSProperties } from 'react';
+import { useEffect, type CSSProperties } from 'react';
 
 export const StoryRootDecorator: Decorator = (Story, context) => {
-  const { lang, storyRootClassname, zoom } = context.globals;
+  const { dir, lang, storyRootClassname, title, zoom } = context.globals;
   const style: CSSProperties = zoom ? { zoom } : {};
-  const dir = lang === 'ar' ? 'rtl' : undefined;
+
+  // In Storybook there are different view modes. When looking at all stories,
+  // the url is something like: `iframe.html?viewMode=docs&...`
+  //
+  // When looking at one just one Story, the URL is like: `iframe.html?viewMode=docs&...`
+  //
+  // Here we will recongnize such an URL, and render the Story settings on page level,
+  // to conform to the following WCAG 2.2 Success criteria:
+  //
+  // - Page title: https://nldesignsystem.nl/wcag/2.4.2
+  // - Language of the page: https://nldesignsystem.nl/wcag/3.1.1
+  const viewMode = typeof location !== 'undefined' ? new URLSearchParams(location.search).get('viewMode') : '';
+
+  useEffect(() => {
+    if (viewMode === 'story' && typeof document !== 'undefined') {
+      document.title = title || context.name;
+      document.documentElement.lang = lang;
+      document.documentElement.dir = dir || '';
+    } else if (viewMode === 'docs') {
+      // Restore the title, dir and lang to sensible defaults
+      document.title = context.title;
+      document.documentElement.lang = 'nl';
+      document.documentElement.dir = 'ltr';
+    }
+  }, [context.name]);
 
   return (
     <div data-story-root className={storyRootClassname} lang={lang} dir={dir} style={style}>

--- a/packages/storybook-test/src/WcagAudit.ts
+++ b/packages/storybook-test/src/WcagAudit.ts
@@ -163,6 +163,7 @@ export type WcagTest = (typeof WCAG22_AA_LEVEL)[number];
 export const isWcagTest = enumGuard(WCAG22_AA_LEVEL);
 
 export interface WcagAudit {
+  author: string;
   baseline: string;
   date: string;
   fail: WcagTest[];

--- a/packages/storybook-test/src/WcagAuditReport.tsx
+++ b/packages/storybook-test/src/WcagAuditReport.tsx
@@ -1,23 +1,105 @@
 import { useOf } from '@storybook/blocks';
 import uniq from 'lodash-es/uniq';
+import without from 'lodash-es/without';
+import { successCriteria, versionSort } from './wcag22';
 import { isWcagTest, WCAG22_AA_LEVEL, WcagAudit, WcagTest } from './WcagAudit';
 
+interface WcagReference {
+  href: string;
+  linkText: string;
+  sortKey: string;
+}
+
 export function WcagAuditReport() {
-  const resolvedOf = useOf<'story'>('story');
-  const wcagAudit: WcagAudit = resolvedOf.story.parameters['wcagAudit'];
+  const meta = useOf<'meta'>('meta');
+  const wcagAudit: WcagAudit = meta.csfFile?.meta?.parameters && meta.csfFile?.meta?.parameters['wcagAudit'];
+  const wcagStories = Object.values(meta.csfFile?.stories || {}); //.filter((story) => story.parameters.wcagAudit);
+
+  const baselineVersions = [
+    {
+      date: '2024-12-01',
+      href: 'https://nldesignsystem.nl/baseline/2024-12',
+      text: 'NL Design System Baseline: december 2024',
+    },
+    {
+      date: '2025-01-01',
+      href: 'https://nldesignsystem.nl/baseline/2025-01',
+      text: 'NL Design System Baseline: januari 2025',
+    },
+  ];
 
   if (!wcagAudit) {
     return null;
   }
 
-  const empty: string[] = [];
-  const cannotTell = uniq(wcagAudit.cannotTell || empty).filter(isWcagTest);
-  const notApplicable = (wcagAudit.notApplicable || empty).filter(isWcagTest);
-  const pass = (wcagAudit.pass || empty).filter(isWcagTest);
-  const fail = (wcagAudit.fail || empty).filter(isWcagTest);
-  const notTested = (wcagAudit.notTested || empty).filter(isWcagTest);
+  const createWcagAudit = (parameters: object & Partial<WcagAudit>) => {
+    const empty: string[] = [];
+    const cannotTell = uniq(parameters.cannotTell || empty).filter(isWcagTest);
+    const notApplicable = (parameters.notApplicable || empty).filter(isWcagTest);
+    const pass = (parameters.pass || empty).filter(isWcagTest);
+    const fail = (parameters.fail || empty).filter(isWcagTest);
+    const notTested = (parameters.notTested || empty).filter(isWcagTest);
 
-  const all: WcagTest[] = [...cannotTell, ...fail, ...notApplicable, ...notTested, ...pass];
+    const all: WcagTest[] = [...cannotTell, ...fail, ...notApplicable, ...notTested, ...pass];
+
+    return {
+      all,
+      author: parameters.author,
+      cannotTell,
+      date: parameters.date,
+      fail,
+      notApplicable,
+      notTested,
+      pass,
+    };
+  };
+
+  const extendAudit = (partialAudit: Partial<WcagAudit>, baseAudit: Partial<WcagAudit>) => {
+    let cannotTell = uniq([...(baseAudit.cannotTell || []), ...(partialAudit.cannotTell || [])]);
+    const fail = uniq([...(baseAudit.fail || []), ...(partialAudit.fail || [])]);
+    let notApplicable = uniq([...(baseAudit.notApplicable || []), ...(partialAudit.notApplicable || [])]);
+    let notTested = uniq([...(baseAudit.notTested || []), ...(partialAudit.notTested || [])]);
+    let pass = uniq([...(baseAudit.pass || []), ...(partialAudit.pass || [])]);
+
+    notApplicable = without(notApplicable, ...[...fail, ...cannotTell, ...pass, ...notTested]);
+    notTested = without(notTested, ...[...fail, ...cannotTell, ...pass]);
+    cannotTell = without(cannotTell, ...[...fail, ...pass]);
+    pass = without(pass, ...fail);
+
+    const all: WcagTest[] = [...cannotTell, ...fail, ...notApplicable, ...notTested, ...pass];
+
+    return {
+      ...baseAudit,
+      ...partialAudit,
+      all,
+      cannotTell,
+      fail,
+      notApplicable,
+      notTested,
+      pass,
+    };
+  };
+
+  const baseAudit = createWcagAudit(
+    (meta.csfFile?.meta?.parameters && meta.csfFile?.meta?.parameters['wcagAudit']) || {},
+  );
+
+  const createWcagReferences = (list: WcagTest[]): WcagReference[] =>
+    list
+      .map((test: WcagTest) => {
+        const successCriteriumData = successCriteria.find(({ url }) => url === test);
+        const href = successCriteriumData ? `https://nldesignsystem.nl/wcag/${successCriteriumData.sc}` : test;
+        const linkText = successCriteriumData
+          ? `WCAG-succescriterium ${successCriteriumData.sc} ${successCriteriumData.nl.title}`
+          : test;
+        const sortKey = successCriteriumData ? successCriteriumData.sc : '';
+        return {
+          href,
+          linkText,
+          sortKey,
+        };
+      })
+      .sort((a, b) => versionSort(a.sortKey, b.sortKey));
 
   const Result = ({ label, list }: { label: string; list: WcagTest[] }) =>
     list.length >= 1 ? (
@@ -26,11 +108,13 @@ export function WcagAuditReport() {
           {label}: {list.length}
         </summary>
         <ul>
-          {list.map((test) => (
-            <li key={test}>
-              <a href={test}>{test}</a>
-            </li>
-          ))}
+          {createWcagReferences(list).map(({ href, linkText }) => {
+            return (
+              <li key={href}>
+                <a href={href}>{linkText}</a>
+              </li>
+            );
+          })}
         </ul>
       </details>
     ) : (
@@ -39,34 +123,139 @@ export function WcagAuditReport() {
       </p>
     );
 
+  const CommonData = () => (
+    <>
+      <dl>
+        <div>
+          <dt>Evaluatiemethode:</dt>
+          <dd>WCAG-EM 1.0</dd>
+        </div>
+        <div>
+          <dt>Beoogd conformiteitsniveau:</dt>
+          <dd>
+            WCAG 2.2 Niveau AA, volgens de <a href="https://nldesignsystem.nl/baseline">NL Design System Baseline</a>
+          </dd>
+        </div>
+        <div>
+          <dt>Opdrachtgever:</dt>
+          <dd>
+            <a href="https://nldesignsystem.nl/project/kernteam">Design System Lead van NL Design System</a>
+          </dd>
+        </div>
+        <div>
+          <dt>Reikweidte van het onderzoek:</dt>
+          <dd>
+            Per story wordt er 1 los WCAG-EM onderzoek gedaan, omdat de stories niet verbonden zijn en geen gedeelde
+            context hebben. De <a href="https://www.w3.org/TR/WCAG-EM/#step1a">reikwijdte van dat onderzoek</a> is dus
+            alleen 1 losse webpagina. Voor de steekproef moet je de webpagina in een eigen window openen, in plaats van
+            als Story bekijken als onderdeel van Storybook.
+          </dd>
+        </div>
+        <div>
+          <dt>Gebruikte technologie:</dt>
+          <dd>
+            <ul>
+              <li>CSS</li>
+              <li>HTML</li>
+              <li>JavaScript</li>
+              <li>React</li>
+            </ul>
+          </dd>
+        </div>
+      </dl>
+      <p>
+        Neem contact op met <a href="https://nldesignsystem.nl/colofon">NL Design System</a> voor vragen over deze
+        toegankelijkheidsverklaring.
+      </p>
+    </>
+  );
+
   return (
     <div>
-      <h2>WCAG evaluatie</h2>
-      <p>
-        Evaluatie op{' '}
-        {new Intl.DateTimeFormat('nl-NL', {
-          dateStyle: 'full',
-        }).format(new Date(wcagAudit.date))}{' '}
-        van {all.length} van de {WCAG22_AA_LEVEL.length} succescriteria voor WCAG 2.2 Niveau AA.
-      </p>
-      <p>De steekproef bestaat uit de stories van deze component.</p>
-      <ul>
-        <li>
-          <Result label="Voldoet" list={pass} />
-        </li>
-        <li>
-          <Result label="Voldoet niet" list={fail} />
-        </li>
-        <li>
-          <Result label="Kan niet worden vastgesteld" list={cannotTell} />
-        </li>
-        <li>
-          <Result label="Niet van toepassing" list={notApplicable} />
-        </li>
-        <li>
-          <Result label="Niet getest" list={notTested} />
-        </li>
-      </ul>
+      <h2>Toegankelijkheidsverklaring</h2>
+      {CommonData()}
+      {wcagStories.map((story) => {
+        const fullReport = false;
+        const baseUrl = typeof location !== 'undefined' ? location.href : '';
+        const relativeUrl = `./iframe.html?${new URLSearchParams({
+          id: story.id,
+          args: '',
+          globals: '',
+          viewMode: 'story',
+        }).toString()}`;
+        const url = baseUrl ? new URL(relativeUrl, baseUrl).toString() : relativeUrl;
+
+        const partialAudit = createWcagAudit((story.parameters && story.parameters['wcagAudit']) || {});
+        const wcagAudit = extendAudit(partialAudit, baseAudit);
+
+        const baseline =
+          typeof wcagAudit.date === 'string' &&
+          baselineVersions.findLast((baseline) => Date.parse(wcagAudit.date || '') >= Date.parse(baseline.date));
+
+        return (
+          <div key={story.id}>
+            <h3>
+              <a href={url} target="wcag_evaluation">
+                {story.name}
+              </a>
+            </h3>
+            {fullReport ? CommonData() : null}
+            <dl>
+              <div>
+                <dt>URL van de steekproef:</dt>
+                <dd>
+                  <code>{url}</code>
+                </dd>
+              </div>
+              {wcagAudit.author ? (
+                <div>
+                  <dt>Onderzoeker:</dt>
+                  <dd>{wcagAudit.author}</dd>
+                </div>
+              ) : null}
+              {wcagAudit.date ? (
+                <div>
+                  <dt>Datum van het onderzoek:</dt>
+                  <dd>
+                    {new Intl.DateTimeFormat('nl-NL', {
+                      dateStyle: 'full',
+                    }).format(new Date(wcagAudit.date))}
+                  </dd>
+                </div>
+              ) : null}
+              {baseline ? (
+                <div>
+                  <dt>Gebruikte software:</dt>
+                  <dd>
+                    Softwareversies van de <a href={baseline.href}>{baseline.text}</a>
+                  </dd>
+                </div>
+              ) : null}
+            </dl>
+            <p>
+              Getoetst op {wcagAudit.all?.length || 0} van de {WCAG22_AA_LEVEL.length} succescriteria voor WCAG 2.2
+              Niveau AA.
+            </p>
+            <ul>
+              <li>
+                <Result label="Voldoet" list={wcagAudit.pass} />
+              </li>
+              <li>
+                <Result label="Voldoet niet" list={wcagAudit.fail} />
+              </li>
+              <li>
+                <Result label="Kan niet worden vastgesteld" list={wcagAudit.cannotTell} />
+              </li>
+              <li>
+                <Result label="Niet van toepassing" list={wcagAudit.notApplicable} />
+              </li>
+              <li>
+                <Result label="Niet getest" list={wcagAudit.notTested} />
+              </li>
+            </ul>
+          </div>
+        );
+      })}
     </div>
   );
 }

--- a/packages/storybook-test/src/wcag21.ts
+++ b/packages/storybook-test/src/wcag21.ts
@@ -1,0 +1,772 @@
+export interface SuccessCriterium {
+  sc: string;
+  title: string;
+  url: string;
+  conformance: string | 'A' | 'AA' | 'AAA';
+  fragment: string;
+  nl: {
+    title: string;
+  };
+  since?: string | 'WCAG20' | 'WCAG21' | 'WCAG22';
+}
+
+export const successCriteria: SuccessCriterium[] = [
+  {
+    conformance: 'A',
+    nl: {
+      title: 'Niet-tekstuele content',
+    },
+    nldesignsystem: true,
+    sc: '1.1.1',
+    title: 'Non-text Content',
+    url: 'https://www.w3.org/TR/WCAG21/#non-text-content',
+  },
+  {
+    conformance: 'A',
+    nl: {
+      title: 'Louter-geluid en louter-videobeeld (vooraf opgenomen)',
+    },
+    nldesignsystem: true,
+    sc: '1.2.1',
+    title: 'Audio-only and Video-only (Prerecorded)',
+    url: 'https://www.w3.org/TR/WCAG21/#audio-only-and-video-only-prerecorded',
+  },
+  {
+    conformance: 'A',
+    nl: {
+      title: 'Ondertitels voor doven en slechthorenden (vooraf opgenomen)',
+    },
+    nldesignsystem: true,
+    sc: '1.2.2',
+    title: 'Captions (Prerecorded)',
+    url: 'https://www.w3.org/TR/WCAG21/#captions-prerecorded',
+  },
+  {
+    conformance: 'A',
+    nl: {
+      title: 'Audiodescriptie of media-alternatief (vooraf opgenomen)',
+    },
+    nldesignsystem: true,
+    sc: '1.2.3',
+    title: 'Audio Description or Media Alternative (Prerecorded)',
+    url: 'https://www.w3.org/TR/WCAG21/#audio-description-or-media-alternative-prerecorded',
+  },
+  {
+    conformance: 'AA',
+    nl: {
+      title: 'Ondertitels voor doven en slechthorenden (live)',
+    },
+    nldesignsystem: true,
+    sc: '1.2.4',
+    title: 'Captions (Live)',
+    url: 'https://www.w3.org/TR/WCAG21/#captions-live',
+  },
+  {
+    conformance: 'AA',
+    nl: {
+      title: 'Audiodescriptie (vooraf opgenomen)',
+    },
+    nldesignsystem: true,
+    sc: '1.2.5',
+    title: 'Audio Description (Prerecorded)',
+    url: 'https://www.w3.org/TR/WCAG21/#audio-description-prerecorded',
+  },
+  {
+    conformance: 'AAA',
+    nl: {
+      title: 'Gebarentaal (vooraf opgenomen)',
+    },
+    sc: '1.2.6',
+    title: 'Sign Language (Prerecorded)',
+    url: 'https://www.w3.org/TR/WCAG21/#sign-language-prerecorded',
+  },
+  {
+    conformance: 'AAA',
+    nl: {
+      title: 'Verlengde audiodescriptie (vooraf opgenomen)',
+    },
+    sc: '1.2.7',
+    title: 'Extended Audio Description (Prerecorded)',
+    url: 'https://www.w3.org/TR/WCAG21/#extended-audio-description-prerecorded',
+  },
+  {
+    conformance: 'AAA',
+    nl: {
+      title: 'Media-alternatief (vooraf opgenomen)',
+    },
+    sc: '1.2.8',
+    title: 'Media Alternative (Prerecorded)',
+    url: 'https://www.w3.org/TR/WCAG21/#media-alternative-prerecorded',
+  },
+  {
+    conformance: 'AAA',
+    nl: {
+      title: 'Louter-geluid (live)',
+    },
+    sc: '1.2.9',
+    title: 'Audio-only (Live)',
+    url: 'https://www.w3.org/TR/WCAG21/#audio-only-live',
+  },
+  {
+    conformance: 'A',
+    nl: {
+      title: 'Info en relaties',
+    },
+    nldesignsystem: true,
+    sc: '1.3.1',
+    title: 'Info and Relationships',
+    url: 'https://www.w3.org/TR/WCAG21/#info-and-relationships',
+  },
+  {
+    conformance: 'A',
+    nl: {
+      title: 'Betekenisvolle volgorde',
+    },
+    nldesignsystem: true,
+    sc: '1.3.2',
+    title: 'Meaningful Sequence',
+    url: 'https://www.w3.org/TR/WCAG21/#meaningful-sequence',
+  },
+  {
+    conformance: 'A',
+    nl: {
+      title: 'Zintuiglijke eigenschappen',
+    },
+    nldesignsystem: true,
+    sc: '1.3.3',
+    title: 'Sensory Characteristics',
+    url: 'https://www.w3.org/TR/WCAG21/#sensory-characteristics',
+  },
+  {
+    conformance: 'AA',
+    nl: {
+      title: 'Weergavestand',
+    },
+    nldesignsystem: true,
+    sc: '1.3.4',
+    title: 'Orientation',
+    url: 'https://www.w3.org/TR/WCAG21/#orientation',
+  },
+  {
+    conformance: 'AA',
+    nl: {
+      title: 'Identificeer het doel van de input',
+    },
+    nldesignsystem: true,
+    sc: '1.3.5',
+    title: 'Identify Input Purpose',
+    url: 'https://www.w3.org/TR/WCAG21/#identify-input-purpose',
+  },
+  {
+    conformance: 'AAA',
+    nl: {
+      title: 'Identificeer het doel',
+    },
+    sc: '1.3.6',
+    title: 'Identify Purpose',
+    url: 'https://www.w3.org/TR/WCAG21/#identify-purpose',
+  },
+  {
+    conformance: 'A',
+    nl: {
+      title: 'Gebruik van kleur',
+    },
+    nldesignsystem: true,
+    sc: '1.4.1',
+    title: 'Use of Color',
+    url: 'https://www.w3.org/TR/WCAG21/#use-of-color',
+  },
+  {
+    conformance: 'A',
+    nl: {
+      title: 'Geluidsbediening',
+    },
+    nldesignsystem: true,
+    sc: '1.4.2',
+    title: 'Audio Control',
+    url: 'https://www.w3.org/TR/WCAG21/#audio-control',
+  },
+  {
+    conformance: 'AA',
+    nl: {
+      title: 'Contrast (minimum)',
+    },
+    nldesignsystem: true,
+    sc: '1.4.3',
+    title: 'Contrast (Minimum)',
+    url: 'https://www.w3.org/TR/WCAG21/#contrast-minimum',
+  },
+  {
+    conformance: 'AA',
+    nl: {
+      title: 'Herschalen van tekst',
+    },
+    nldesignsystem: true,
+    sc: '1.4.4',
+    title: 'Resize text',
+    url: 'https://www.w3.org/TR/WCAG21/#resize-text',
+  },
+  {
+    conformance: 'AA',
+    nl: {
+      title: 'Afbeeldingen van tekst',
+    },
+    nldesignsystem: true,
+    sc: '1.4.5',
+    title: 'Images of Text',
+    url: 'https://www.w3.org/TR/WCAG21/#images-of-text',
+  },
+  {
+    conformance: 'AAA',
+    nl: {
+      title: 'Contrast (versterkt)',
+    },
+    sc: '1.4.6',
+    title: 'Contrast (Enhanced)',
+    url: 'https://www.w3.org/TR/WCAG21/#contrast-enhanced',
+  },
+  {
+    conformance: 'AAA',
+    nl: {
+      title: 'Weinig of geen achtergrondgeluid',
+    },
+    sc: '1.4.7',
+    title: 'Low or No Background Audio',
+    url: 'https://www.w3.org/TR/WCAG21/#low-or-no-background-audio',
+  },
+  {
+    conformance: 'AAA',
+    nl: {
+      title: 'Visuele weergave',
+    },
+    sc: '1.4.8',
+    title: 'Visual Presentation',
+    url: 'https://www.w3.org/TR/WCAG21/#visual-presentation',
+  },
+  {
+    conformance: 'AAA',
+    nl: {
+      title: 'Afbeeldingen van tekst (geen uitzondering)',
+    },
+    sc: '1.4.9',
+    title: 'Images of Text (No Exception)',
+    url: 'https://www.w3.org/TR/WCAG21/#images-of-text-no-exception',
+  },
+  {
+    conformance: 'AA',
+    nl: {
+      title: 'Reflow',
+    },
+    nldesignsystem: true,
+    sc: '1.4.10',
+    title: 'Reflow',
+    url: 'https://www.w3.org/TR/WCAG21/#reflow',
+  },
+  {
+    conformance: 'AA',
+    nl: {
+      title: 'Contrast van niet-tekstuele content',
+    },
+    nldesignsystem: true,
+    sc: '1.4.11',
+    title: 'Non-text Contrast',
+    url: 'https://www.w3.org/TR/WCAG21/#non-text-contrast',
+  },
+  {
+    conformance: 'AA',
+    nl: {
+      title: 'Tekstafstand',
+    },
+    nldesignsystem: true,
+    sc: '1.4.12',
+    title: 'Text Spacing',
+    url: 'https://www.w3.org/TR/WCAG21/#text-spacing',
+  },
+  {
+    conformance: 'AA',
+    nl: {
+      title: 'Content bij hover of focus',
+    },
+    nldesignsystem: true,
+    sc: '1.4.13',
+    title: 'Content on Hover or Focus',
+    url: 'https://www.w3.org/TR/WCAG21/#content-on-hover-or-focus',
+  },
+  {
+    conformance: 'A',
+    nl: {
+      title: 'Toetsenbord',
+    },
+    nldesignsystem: true,
+    sc: '2.1.1',
+    title: 'Keyboard',
+    url: 'https://www.w3.org/TR/WCAG21/#keyboard',
+  },
+  {
+    conformance: 'A',
+    nl: {
+      title: 'Geen toetsenbordval',
+    },
+    nldesignsystem: true,
+    sc: '2.1.2',
+    title: 'No Keyboard Trap',
+    url: 'https://www.w3.org/TR/WCAG21/#no-keyboard-trap',
+  },
+  {
+    conformance: 'AAA',
+    nl: {
+      title: 'Toetsenbord (geen uitzondering)',
+    },
+    sc: '2.1.3',
+    title: 'Keyboard (No Exception)',
+    url: 'https://www.w3.org/TR/WCAG21/#keyboard-no-exception',
+  },
+  {
+    conformance: 'A',
+    nl: {
+      title: 'Enkel teken sneltoetsen',
+    },
+    nldesignsystem: true,
+    sc: '2.1.4',
+    title: 'Character Key Shortcuts',
+    url: 'https://www.w3.org/TR/WCAG21/#character-key-shortcuts',
+  },
+  {
+    conformance: 'A',
+    nl: {
+      title: 'Timing aanpasbaar',
+    },
+    nldesignsystem: true,
+    sc: '2.2.1',
+    title: 'Timing Adjustable',
+    url: 'https://www.w3.org/TR/WCAG21/#timing-adjustable',
+  },
+  {
+    conformance: 'A',
+    nl: {
+      title: 'Pauzeren, stoppen, verbergen',
+    },
+    nldesignsystem: true,
+    sc: '2.2.2',
+    title: 'Pause, Stop, Hide',
+    url: 'https://www.w3.org/TR/WCAG21/#pause-stop-hide',
+  },
+  {
+    conformance: 'AAA',
+    nl: {
+      title: 'Geen timing',
+    },
+    sc: '2.2.3',
+    title: 'No Timing',
+    url: 'https://www.w3.org/TR/WCAG21/#no-timing',
+  },
+  {
+    conformance: 'AAA',
+    nl: {
+      title: 'Onderbrekingen',
+    },
+    sc: '2.2.4',
+    title: 'Interruptions',
+    url: 'https://www.w3.org/TR/WCAG21/#interruptions',
+  },
+  {
+    conformance: 'AAA',
+    nl: {
+      title: 'Herauthentisering',
+    },
+    sc: '2.2.5',
+    title: 'Re-authenticating',
+    url: 'https://www.w3.org/TR/WCAG21/#re-authenticating',
+  },
+  {
+    conformance: 'AAA',
+    nl: {
+      title: 'Time-outs',
+    },
+    sc: '2.2.6',
+    title: 'Timeouts',
+    url: 'https://www.w3.org/TR/WCAG21/#timeouts',
+  },
+  {
+    conformance: 'A',
+    nl: {
+      title: 'Drie flitsen of beneden drempelwaarde',
+    },
+    nldesignsystem: true,
+    sc: '2.3.1',
+    title: 'Three Flashes or Below Threshold',
+    url: 'https://www.w3.org/TR/WCAG21/#three-flashes-or-below-threshold',
+  },
+  {
+    conformance: 'AAA',
+    nl: {
+      title: 'Drie flitsen',
+    },
+    sc: '2.3.2',
+    title: 'Three Flashes',
+    url: 'https://www.w3.org/TR/WCAG21/#three-flashes',
+  },
+  {
+    conformance: 'AAA',
+    nl: {
+      title: 'Animatie uit interacties',
+    },
+    sc: '2.3.3',
+    title: 'Animation from Interactions',
+    url: 'https://www.w3.org/TR/WCAG21/#animation-from-interactions',
+  },
+  {
+    conformance: 'A',
+    nl: {
+      title: 'Blokken omzeilen',
+    },
+    nldesignsystem: true,
+    sc: '2.4.1',
+    title: 'Bypass Blocks',
+    url: 'https://www.w3.org/TR/WCAG21/#bypass-blocks',
+  },
+  {
+    conformance: 'A',
+    nl: {
+      title: 'Paginatitel',
+    },
+    nldesignsystem: true,
+    sc: '2.4.2',
+    title: 'Page Titled',
+    url: 'https://www.w3.org/TR/WCAG21/#page-titled',
+  },
+  {
+    conformance: 'A',
+    nl: {
+      title: 'Focus volgorde',
+    },
+    nldesignsystem: true,
+    sc: '2.4.3',
+    title: 'Focus Order',
+    url: 'https://www.w3.org/TR/WCAG21/#focus-order',
+  },
+  {
+    conformance: 'A',
+    nl: {
+      title: 'Linkdoel (in context)',
+    },
+    nldesignsystem: true,
+    sc: '2.4.4',
+    title: 'Link Purpose (In Context)',
+    url: 'https://www.w3.org/TR/WCAG21/#link-purpose-in-context',
+  },
+  {
+    conformance: 'AA',
+    nl: {
+      title: 'Meerdere manieren',
+    },
+    nldesignsystem: true,
+    sc: '2.4.5',
+    title: 'Multiple Ways',
+    url: 'https://www.w3.org/TR/WCAG21/#multiple-ways',
+  },
+  {
+    conformance: 'AA',
+    nl: {
+      title: 'Koppen en labels',
+    },
+    nldesignsystem: true,
+    sc: '2.4.6',
+    title: 'Headings and Labels',
+    url: 'https://www.w3.org/TR/WCAG21/#headings-and-labels',
+  },
+  {
+    conformance: 'AA',
+    nl: {
+      title: 'Focus zichtbaar',
+    },
+    nldesignsystem: true,
+    sc: '2.4.7',
+    title: 'Focus Visible',
+    url: 'https://www.w3.org/TR/WCAG21/#focus-visible',
+  },
+  {
+    conformance: 'AAA',
+    nl: {
+      title: 'Locatie',
+    },
+    sc: '2.4.8',
+    title: 'Location',
+    url: 'https://www.w3.org/TR/WCAG21/#location',
+  },
+  {
+    conformance: 'AAA',
+    nl: {
+      title: 'Linkdoel (alleen link)',
+    },
+    sc: '2.4.9',
+    title: 'Link Purpose (Link Only)',
+    url: 'https://www.w3.org/TR/WCAG21/#link-purpose-link-only',
+  },
+  {
+    conformance: 'AAA',
+    nl: {
+      title: 'Paragraafkoppen',
+    },
+    nldesignsystem: true,
+    sc: '2.4.10',
+    title: 'Section Headings',
+    url: 'https://www.w3.org/TR/WCAG21/#section-headings',
+  },
+  {
+    conformance: 'A',
+    nl: {
+      title: 'Aanwijzergebaren',
+    },
+    nldesignsystem: true,
+    sc: '2.5.1',
+    title: 'Pointer Gestures',
+    url: 'https://www.w3.org/TR/WCAG21/#pointer-gestures',
+  },
+  {
+    conformance: 'A',
+    nl: {
+      title: 'Aanwijzerannulering',
+    },
+    nldesignsystem: true,
+    sc: '2.5.2',
+    title: 'Pointer Cancellation',
+    url: 'https://www.w3.org/TR/WCAG21/#pointer-cancellation',
+  },
+  {
+    conformance: 'A',
+    nl: {
+      title: 'Label in naam',
+    },
+    nldesignsystem: true,
+    sc: '2.5.3',
+    title: 'Label in Name',
+    url: 'https://www.w3.org/TR/WCAG21/#label-in-name',
+  },
+  {
+    conformance: 'A',
+    nl: {
+      title: 'Bewegingsactivering',
+    },
+    nldesignsystem: true,
+    sc: '2.5.4',
+    title: 'Motion Actuation',
+    url: 'https://www.w3.org/TR/WCAG21/#motion-actuation',
+  },
+  {
+    conformance: 'AAA',
+    nl: {
+      title: 'Grootte van het aanwijsgebied (uitgebreid)',
+    },
+    sc: '2.5.5',
+    title: 'Target Size',
+    url: 'https://www.w3.org/TR/WCAG21/#target-size',
+  },
+  {
+    conformance: 'AAA',
+    nl: {
+      title: 'Input gelijktijdige invoermechanismen',
+    },
+    sc: '2.5.6',
+    title: 'Concurrent Input Mechanisms',
+    url: 'https://www.w3.org/TR/WCAG21/#concurrent-input-mechanisms',
+  },
+  {
+    conformance: 'A',
+    nl: {
+      title: 'Taal van de pagina',
+    },
+    nldesignsystem: true,
+    sc: '3.1.1',
+    title: 'Language of Page',
+    url: 'https://www.w3.org/TR/WCAG21/#language-of-page',
+  },
+  {
+    conformance: 'AA',
+    nl: {
+      title: 'Taal van onderdelen',
+    },
+    nldesignsystem: true,
+    sc: '3.1.2',
+    title: 'Language of Parts',
+    url: 'https://www.w3.org/TR/WCAG21/#language-of-parts',
+  },
+  {
+    conformance: 'AAA',
+    nl: {
+      title: 'Ongebruikelijke woorden',
+    },
+    sc: '3.1.3',
+    title: 'Unusual Words',
+    url: 'https://www.w3.org/TR/WCAG21/#unusual-words',
+  },
+  {
+    conformance: 'AAA',
+    nl: {
+      title: 'Afkortingen',
+    },
+    sc: '3.1.4',
+    title: 'Abbreviations',
+    url: 'https://www.w3.org/TR/WCAG21/#abbreviations',
+  },
+  {
+    conformance: 'AAA',
+    nl: {
+      title: 'Leesniveau',
+    },
+    sc: '3.1.5',
+    title: 'Reading Level',
+    url: 'https://www.w3.org/TR/WCAG21/#reading-level',
+  },
+  {
+    conformance: 'AAA',
+    nl: {
+      title: 'Uitspraak',
+    },
+    sc: '3.1.6',
+    title: 'Pronunciation',
+    url: 'https://www.w3.org/TR/WCAG21/#pronunciation',
+  },
+  {
+    conformance: 'A',
+    nl: {
+      title: 'Bij focus',
+    },
+    nldesignsystem: true,
+    sc: '3.2.1',
+    title: 'On Focus',
+    url: 'https://www.w3.org/TR/WCAG21/#on-focus',
+  },
+  {
+    conformance: 'A',
+    nl: {
+      title: 'Bij input',
+    },
+    nldesignsystem: true,
+    sc: '3.2.2',
+    title: 'On Input',
+    url: 'https://www.w3.org/TR/WCAG21/#on-input',
+  },
+  {
+    conformance: 'AA',
+    nl: {
+      title: 'Consistente navigatie',
+    },
+    nldesignsystem: true,
+    sc: '3.2.3',
+    title: 'Consistent Navigation',
+    url: 'https://www.w3.org/TR/WCAG21/#consistent-navigation',
+  },
+  {
+    conformance: 'AA',
+    nl: {
+      title: 'Consistente identificatie',
+    },
+    nldesignsystem: true,
+    sc: '3.2.4',
+    title: 'Consistent Identification',
+    url: 'https://www.w3.org/TR/WCAG21/#consistent-identification',
+  },
+  {
+    conformance: 'AAA',
+    nl: {
+      title: 'Verandering op verzoek',
+    },
+    sc: '3.2.5',
+    title: 'Change on Request',
+    url: 'https://www.w3.org/TR/WCAG21/#change-on-request',
+  },
+  {
+    conformance: 'A',
+    nl: {
+      title: 'Foutidentificatie',
+    },
+    nldesignsystem: true,
+    sc: '3.3.1',
+    title: 'Error Identification',
+    url: 'https://www.w3.org/TR/WCAG21/#error-identification',
+  },
+  {
+    conformance: 'A',
+    nl: {
+      title: 'Labels of instructies',
+    },
+    nldesignsystem: true,
+    sc: '3.3.2',
+    title: 'Labels or Instructions',
+    url: 'https://www.w3.org/TR/WCAG21/#labels-or-instructions',
+  },
+  {
+    conformance: 'AA',
+    nl: {
+      title: 'Foutsuggestie',
+    },
+    nldesignsystem: true,
+    sc: '3.3.3',
+    title: 'Error Suggestion',
+    url: 'https://www.w3.org/TR/WCAG21/#error-suggestion',
+  },
+  {
+    conformance: 'AA',
+    nl: {
+      title: 'Foutpreventie (wettelijk, financieel, gegevens)',
+    },
+    nldesignsystem: true,
+    sc: '3.3.4',
+    title: 'Error Prevention (Legal, Financial, Data)',
+    url: 'https://www.w3.org/TR/WCAG21/#error-prevention-legal-financial-data',
+  },
+  {
+    conformance: 'AAA',
+    nl: {
+      title: 'Hulp',
+    },
+    sc: '3.3.5',
+    title: 'Help',
+    url: 'https://www.w3.org/TR/WCAG21/#help',
+  },
+  {
+    conformance: 'AAA',
+    nl: {
+      title: 'Foutpreventie (alle)',
+    },
+    sc: '3.3.6',
+    title: 'Error Prevention (All)',
+    url: 'https://www.w3.org/TR/WCAG21/#error-prevention-all',
+  },
+  {
+    conformance: 'A',
+    nl: {
+      title: 'Parsen',
+    },
+    nldesignsystem: true,
+    sc: '4.1.1',
+    title: 'Parsing',
+    url: 'https://www.w3.org/TR/WCAG21/#parsing',
+  },
+  {
+    conformance: 'A',
+    nl: {
+      title: 'Naam, rol, waarde',
+    },
+    nldesignsystem: true,
+    sc: '4.1.2',
+    title: 'Name, Role, Value',
+    url: 'https://www.w3.org/TR/WCAG21/#name-role-value',
+  },
+  {
+    conformance: 'AA',
+    nl: {
+      title: 'Statusberichten',
+    },
+    nldesignsystem: true,
+    sc: '4.1.3',
+    title: 'Status Messages',
+    url: 'https://www.w3.org/TR/WCAG21/#status-messages',
+  },
+].map((sc) => ({
+  ...sc,
+  fragment: new URL(sc.url).hash.replace(/^#/, ''),
+}));
+
+export const successCriteriaMap = new Map(successCriteria.map((data) => [data.sc, data]));

--- a/packages/storybook-test/src/wcag22.ts
+++ b/packages/storybook-test/src/wcag22.ts
@@ -1,0 +1,127 @@
+import type { SuccessCriterium } from './wcag21';
+import { successCriteria as wcag21 } from './wcag21';
+
+const stringSort = (a: string, b: string): number => (a === b ? 0 : a > b ? 1 : -1);
+
+// https://stackoverflow.com/questions/40201533/sort-version-dotted-number-strings-in-javascript
+const versionPad = (str: string) => str.replace(/\d+/g, (n) => String(Number(n) + 100000));
+
+export const versionSort = (a: string, b: string): number => stringSort(versionPad(a), versionPad(b));
+
+export const deprecatedCriteria = [
+  {
+    conformance: 'A',
+    nl: {
+      title: 'Parsen',
+    },
+    sc: '4.1.1',
+    since: 'WCAG22',
+    title: 'Parsing',
+    url: 'https://www.w3.org/TR/WCAG21/#parsing',
+  },
+];
+
+export const successCriteria: SuccessCriterium[] = [
+  ...wcag21.map((obj) => ({
+    ...obj,
+    url: obj.url.replace(/WCAG21/i, 'WCAG22'),
+  })),
+  {
+    conformance: 'AA',
+    nl: {
+      title: 'Focus niet bedekt (minimum)',
+    },
+    sc: '2.4.11',
+    since: 'WCAG22',
+    title: 'Focus Not Obscured (Minimum)',
+    url: 'https://www.w3.org/TR/WCAG22/#focus-not-obscured-minimum',
+  },
+  {
+    conformance: 'AAA',
+    nl: {
+      title: 'Focus niet bedekt (uitgebreid)',
+    },
+    sc: '2.4.12',
+    since: 'WCAG22',
+    title: 'Focus Not Obscured (Enhanced)',
+    url: 'https://www.w3.org/TR/WCAG22/#focus-not-obscured-enhanced',
+  },
+  {
+    conformance: 'AAA',
+    nl: {
+      title: 'Focusweergave',
+    },
+    sc: '2.4.13',
+    since: 'WCAG22',
+    title: 'Focus Appearance',
+    url: 'https://www.w3.org/TR/WCAG22/#focus-appearance',
+  },
+  {
+    conformance: 'AA',
+    nl: {
+      title: 'Sleepbewegingen',
+    },
+    sc: '2.5.7',
+    since: 'WCAG22',
+    title: 'Dragging Movements',
+    url: 'https://www.w3.org/TR/WCAG22/#dragging-movements',
+  },
+  {
+    conformance: 'AA',
+    nl: {
+      title: 'Grootte van het aanwijsgebied (minimum)',
+    },
+    sc: '2.5.8',
+    since: 'WCAG22',
+    title: 'Target Size (minimum)',
+    url: 'https://www.w3.org/TR/WCAG22/#target-size-minimum',
+  },
+  {
+    conformance: 'A',
+    nl: {
+      title: 'Consistente hulp',
+    },
+    sc: '3.2.6',
+    since: 'WCAG22',
+    title: 'Consistent Help',
+    url: 'https://www.w3.org/TR/WCAG22/#consistent-help',
+  },
+  {
+    conformance: 'A',
+    nl: {
+      title: 'Overbodige invoer',
+    },
+    sc: '3.3.7',
+    since: 'WCAG22',
+    title: 'Redundant Entry',
+    url: 'https://www.w3.org/TR/WCAG22/#redundant-entry',
+  },
+  {
+    conformance: 'AA',
+    nl: {
+      title: 'Toegankelijke authenticatie (minimum)',
+    },
+    sc: '3.3.8',
+    since: 'WCAG22',
+    title: 'Accessible Authentication (Minimum)',
+    url: 'https://www.w3.org/TR/WCAG22/#accessible-authentication-minimum',
+  },
+  {
+    conformance: 'AAA',
+    nl: {
+      title: 'Toegankelijke authenticatie (uitgebreid)',
+    },
+    sc: '3.3.9',
+    since: 'WCAG22',
+    title: 'Accessible Authentication (Enhanced)',
+    url: 'https://www.w3.org/TR/WCAG22/#accessible-authentication-enhanced',
+  },
+]
+  .sort((a, b) => versionSort(a.sc, b.sc))
+  .map((sc) => ({
+    ...sc,
+    fragment: new URL(sc.url).hash.replace(/^#/, ''),
+  }))
+  .filter(({ sc }) => !deprecatedCriteria.find((deprecated) => deprecated.sc === sc));
+
+export const successCriteriaMap = new Map(successCriteria.map((data) => [data.sc, data]));

--- a/packages/storybook-test/stories/paragraph/paragraph.stories.tsx
+++ b/packages/storybook-test/stories/paragraph/paragraph.stories.tsx
@@ -101,10 +101,6 @@ const meta = {
     ],
     tokens,
     wcagAudit: {
-      baseline: 'http://nldesignsystem.nl/wcag/baseline#2024-12',
-      cannotTell: [],
-      date: '2024-12-12',
-      fail: [],
       notApplicable: [
         WCAG22_111_NON_TEXT_CONTENT,
         WCAG22_121_AUDIO_ONLY_AND_VIDEO_ONLY_PRERECORDED,
@@ -157,14 +153,7 @@ const meta = {
         WCAG22_413_STATUS_MESSAGES,
       ],
       notTested: [],
-      pass: [
-        WCAG22_131_INFO_AND_RELATIONSHIPS,
-        WCAG22_1410_REFLOW,
-        WCAG22_1412_TEXT_SPACING,
-        WCAG22_143_CONTRAST_MINIMUM,
-        WCAG22_144_RESIZE_TEXT,
-        WCAG22_312_LANGUAGE_OF_PARTS,
-      ],
+      pass: [],
     },
   },
   title: 'Componenten/Paragraph',
@@ -175,12 +164,14 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
-  name: 'Paragraph',
+  name: 'Paragraph: een korte zin',
   args: {
     children: 'Op brute wĳze ving de schooljuf de quasi-kalme lynx.',
     purpose: undefined,
   },
   globals: {
+    dir: 'ltr',
+    lang: 'nl',
     viewport: { value: 'wcag100' },
   },
   parameters: {
@@ -190,16 +181,30 @@ export const Default: Story = {
       },
     },
     status: { type: [] },
+    wcagAudit: {
+      author: 'Rian Rietveld',
+      date: '2024-12-12',
+      pass: [
+        WCAG22_131_INFO_AND_RELATIONSHIPS,
+        WCAG22_1410_REFLOW,
+        WCAG22_1412_TEXT_SPACING,
+        WCAG22_143_CONTRAST_MINIMUM,
+        WCAG22_144_RESIZE_TEXT,
+        WCAG22_312_LANGUAGE_OF_PARTS,
+      ],
+    },
   },
 };
 
 export const LeadParagraph: Story = {
-  name: 'Lead Paragraph',
+  name: 'Lead Paragraph: een korte zin',
   args: {
     children: 'Op brute wĳze ving de schooljuf de quasi-kalme lynx.',
     purpose: 'lead',
   },
   globals: {
+    dir: 'ltr',
+    lang: 'nl',
     viewport: { value: 'wcag100' },
   },
   parameters: {
@@ -210,17 +215,31 @@ export const LeadParagraph: Story = {
       },
     },
     status: { type: [] },
+    wcagAudit: {
+      author: 'Rian Rietveld',
+      date: '2024-12-12',
+      pass: [
+        WCAG22_131_INFO_AND_RELATIONSHIPS,
+        WCAG22_1410_REFLOW,
+        WCAG22_1412_TEXT_SPACING,
+        WCAG22_143_CONTRAST_MINIMUM,
+        WCAG22_144_RESIZE_TEXT,
+        WCAG22_312_LANGUAGE_OF_PARTS,
+      ],
+    },
   },
 };
 
 export const LongParagraph: Story = {
-  name: 'Paragraph met lange tekst',
+  name: 'Paragraph: een lange alinea',
   args: {
     children:
       'In de laatste dagen, toen ik uit Italië naar Engeland terugkeerde, besloot ik, liever dan al den tijd, dien ik te paard moest zitten, met smakelooze en onwetenschappelijke praatjes te slijten, zoo nu en dan of bij mij zelf over een onderwerp uit onze gemeenschappelijke letteroefeningen na te denken of mij te vermeien in de herinnering aan de even geleerde als dierbare vrienden, die ik hier had achtergelaten. Onder dezen kwam uw beeld, mijn beste Morus, mij zeker het allereerst voor den geest en de herinnering aan U, ofschoon wij ver van elkander waren, was mij even aangenaam, als uw omgang was, toen ik U nog van aangezicht tot aangezicht placht te zien, het aangenaamste—ik mag sterven, als het niet waar is—van al wat mij ooit in mijn leven te beurt is gevallen. Daarom vatte ik, omdat ik meende in allen gevalle iets te moeten doen en die tijd mij weinig geschikt voorkwam om een ernstig onderwerp te overdenken, het plan op een boertige lofrede op Moria (de Zotheid) te houden. “Welke Pallas heeft U op die gedachte gebracht?” zult ge zeggen. Vooreerst deed uw geslachtsnaam Morus mij dit plan opvatten, die even dicht bij het woord Moria komt, als gij ver van de zaak af zijt of liever, volgens aller eenstemmig getuigenis, daarmede volstrekt niets gemeen hebt. Verder vermoedde ik, dat deze speling van ons vernuft bovenal uw goedkeuring zou wegdragen, omdat gij in dergelijke jokkernijen, waarbij, zoo ik goed zie, nergens geleerdheid en geest kan gemist worden, bijzonder veel smaak vindt en in het dagelijksche leven als een Democritus pleegt op te treden. Ofschoon gij door uw buitengewone scherpzinnigheid gewoonlijk hemelsbreed in gevoelen van het gemeene volk verschilt, zijt gij toch door de ongeloofelijke zachtheid en meegaandheid van uw karakter niet alleen in staat om met allerlei menschen in alle omstandigheden des levens om te gaan, maar vindt gij er ook een genot in. Deze kleine verhandeling zult gij daarom gaarne aannemen als een aandenken van uw vriend en gij zult ook haar verdediging gaarne aanvaarden, want zij is u toegewijd en daarom voortaan Uw eigendom, niet het mijne.',
   },
 
   globals: {
+    dir: 'ltr',
+    lang: 'nl',
     viewport: { value: 'wcag100' },
   },
   parameters: {
@@ -234,6 +253,18 @@ De tekst is op normale schermgroottes verdeeld over meerdere regels, waardoor je
       },
     },
     status: { type: [] },
+    wcagAudit: {
+      author: 'Rian Rietveld',
+      date: '2024-12-12',
+      pass: [
+        WCAG22_131_INFO_AND_RELATIONSHIPS,
+        WCAG22_1410_REFLOW,
+        WCAG22_1412_TEXT_SPACING,
+        WCAG22_143_CONTRAST_MINIMUM,
+        WCAG22_144_RESIZE_TEXT,
+        WCAG22_312_LANGUAGE_OF_PARTS,
+      ],
+    },
   },
 };
 
@@ -261,11 +292,13 @@ const longWordsNl = [
 ].sort();
 
 export const ParagraphWordBreak: Story = {
-  name: 'Paragraph met word-break',
+  name: 'Paragraph: woorden die niet op 1 regel passen',
   args: {
     children: `In de praktijk komen er regelmatig lange woorden voor. Bijvoorbeeld: ${longWordsNl.join(', ')}.`,
   },
   globals: {
+    dir: 'ltr',
+    lang: 'nl',
     viewport: { value: 'wcag100' },
   },
   parameters: {
@@ -277,18 +310,36 @@ Woordafbreking gebruiken voor tekst is belangrijk, want je moet voorkomen dat te
       },
     },
     status: { type: [] },
+    wcagAudit: {
+      author: 'Rian Rietveld',
+      date: '2024-12-12',
+      pass: [
+        WCAG22_131_INFO_AND_RELATIONSHIPS,
+        WCAG22_1410_REFLOW,
+        WCAG22_1412_TEXT_SPACING,
+        WCAG22_143_CONTRAST_MINIMUM,
+        WCAG22_144_RESIZE_TEXT,
+        WCAG22_312_LANGUAGE_OF_PARTS,
+      ],
+    },
   },
 };
 
 export const ParagraphLeadPlusParagraph: Story = {
-  name: 'Paragraph Lead + Paragraph',
+  name: 'Lead Paragraph met daar na een Paragraph',
   args: {
     children:
       'Ditmaal hebben wij het in Friesland gezocht, en ik mag wel zeggen, wij hebben het er gevonden ook. Want dat gewest geeft een afwisseling van velerlei moois te water en te land, oud en nieuw.',
     purpose: 'lead',
   },
   globals: {
+    dir: 'ltr',
+    lang: 'nl',
     viewport: { value: 'wcag100' },
+    wcagAudit: {
+      author: 'Rian Rietveld',
+      date: '2024-12-12',
+    },
   },
   parameters: {
     docs: {
@@ -299,6 +350,18 @@ De tekst is een fragment uit “Friesland” door Jac. P. Thijsse, gesplitst in 
       },
     },
     status: { type: [] },
+    wcagAudit: {
+      author: 'Rian Rietveld',
+      date: '2024-12-12',
+      pass: [
+        WCAG22_131_INFO_AND_RELATIONSHIPS,
+        WCAG22_1410_REFLOW,
+        WCAG22_1412_TEXT_SPACING,
+        WCAG22_143_CONTRAST_MINIMUM,
+        WCAG22_144_RESIZE_TEXT,
+        WCAG22_312_LANGUAGE_OF_PARTS,
+      ],
+    },
   },
   render({ children, ...restProps }) {
     return (
@@ -315,15 +378,14 @@ De tekst is een fragment uit “Friesland” door Jac. P. Thijsse, gesplitst in 
   },
 };
 
-export const ParagraphArabic: Story = {
-  name: 'Paragraph met Arabisch schrift',
+export const ParagraphArabicPage: Story = {
+  name: 'Paragraph بالنص العربي',
   args: {
     children: 'هذه فقرة نصية. وهي ليست فقرة نصية طويلة جدًا، ولكنها فقرة نصية على أية حال.',
-    dir: 'rtl',
-    lang: 'ar',
-    purpose: undefined,
   },
   globals: {
+    dir: 'rtl',
+    lang: 'ar',
     viewport: { value: 'wcag100' },
   },
   parameters: {
@@ -334,11 +396,59 @@ export const ParagraphArabic: Story = {
       },
     },
     status: { type: [] },
+    wcagAudit: {
+      author: 'Rian Rietveld',
+      date: '2024-12-12',
+      pass: [
+        WCAG22_131_INFO_AND_RELATIONSHIPS,
+        WCAG22_1410_REFLOW,
+        WCAG22_1412_TEXT_SPACING,
+        WCAG22_143_CONTRAST_MINIMUM,
+        WCAG22_144_RESIZE_TEXT,
+        WCAG22_312_LANGUAGE_OF_PARTS,
+      ],
+    },
+  },
+};
+
+export const ParagraphArabic: Story = {
+  name: 'Paragraph met Arabisch schrift in een Nederlandstalige pagina',
+  args: {
+    children: 'هذه فقرة نصية. وهي ليست فقرة نصية طويلة جدًا، ولكنها فقرة نصية على أية حال.',
+    dir: 'rtl',
+    lang: 'ar',
+    purpose: undefined,
+  },
+  globals: {
+    dir: 'ltr',
+    lang: 'nl',
+    viewport: { value: 'wcag100' },
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Dit voorbeeld toont een alinea die bestaat uit 1 zin in Arabisch schrift, waarvan de schrijfrichting van rechts naar links is.',
+      },
+    },
+    status: { type: [] },
+    wcagAudit: {
+      author: 'Rian Rietveld',
+      date: '2024-12-12',
+      pass: [
+        WCAG22_131_INFO_AND_RELATIONSHIPS,
+        WCAG22_1410_REFLOW,
+        WCAG22_1412_TEXT_SPACING,
+        WCAG22_143_CONTRAST_MINIMUM,
+        WCAG22_144_RESIZE_TEXT,
+        WCAG22_312_LANGUAGE_OF_PARTS,
+      ],
+    },
   },
 };
 
 export const ParagraphLeadArabic: Story = {
-  name: 'Lead Paragraph met Arabisch schrift',
+  name: 'Lead Paragraph met Arabisch schrift in een Nederlandstalige pagina',
   args: {
     children: 'هذه فقرة نصية. وهي ليست فقرة نصية طويلة جدًا، ولكنها فقرة نصية على أية حال.',
     dir: 'rtl',
@@ -346,6 +456,8 @@ export const ParagraphLeadArabic: Story = {
     purpose: 'lead',
   },
   globals: {
+    dir: 'ltr',
+    lang: 'nl',
     viewport: { value: 'wcag100' },
   },
   parameters: {
@@ -356,16 +468,30 @@ export const ParagraphLeadArabic: Story = {
       },
     },
     status: { type: [] },
+    wcagAudit: {
+      author: 'Rian Rietveld',
+      date: '2024-12-12',
+      pass: [
+        WCAG22_131_INFO_AND_RELATIONSHIPS,
+        WCAG22_1410_REFLOW,
+        WCAG22_1412_TEXT_SPACING,
+        WCAG22_143_CONTRAST_MINIMUM,
+        WCAG22_144_RESIZE_TEXT,
+        WCAG22_312_LANGUAGE_OF_PARTS,
+      ],
+    },
   },
 };
 
 export const ParagraphLongSmallViewport: Story = {
-  name: 'Paragraph in een kleine viewport',
+  name: 'Paragraph met een lange alinea in een kleine viewport',
   args: {
     ...LongParagraph.args,
   },
   decorators: [LargeLineHeightDecorator],
   globals: {
+    dir: 'ltr',
+    lang: 'nl',
     viewport: { value: 'wcag400' },
   },
   parameters: {
@@ -379,16 +505,30 @@ Er moet geen tekst buiten beeld vallen aan de rechterkant, en aan de onderkant m
     status: {
       type: [],
     },
+    wcagAudit: {
+      author: 'Rian Rietveld',
+      date: '2024-12-12',
+      pass: [
+        WCAG22_131_INFO_AND_RELATIONSHIPS,
+        WCAG22_1410_REFLOW,
+        WCAG22_1412_TEXT_SPACING,
+        WCAG22_143_CONTRAST_MINIMUM,
+        WCAG22_144_RESIZE_TEXT,
+        WCAG22_312_LANGUAGE_OF_PARTS,
+      ],
+    },
   },
 };
 
 export const ParagraphLongLargeViewport: Story = {
-  name: 'Paragraph in een grote viewport',
+  name: 'Paragraph met een lange alinea in een grote viewport',
   args: {
     ...LongParagraph.args,
   },
   decorators: [LargeLineHeightDecorator],
   globals: {
+    dir: 'ltr',
+    lang: 'nl',
     viewport: { value: 'wcag100' },
   },
   parameters: {
@@ -402,6 +542,18 @@ Je moet de tekst goed kunnen lezen, en de tekstregels moeten niet breder worden 
     status: {
       type: [],
     },
+    wcagAudit: {
+      author: 'Rian Rietveld',
+      date: '2024-12-12',
+      pass: [
+        WCAG22_131_INFO_AND_RELATIONSHIPS,
+        WCAG22_1410_REFLOW,
+        WCAG22_1412_TEXT_SPACING,
+        WCAG22_143_CONTRAST_MINIMUM,
+        WCAG22_144_RESIZE_TEXT,
+        WCAG22_312_LANGUAGE_OF_PARTS,
+      ],
+    },
   },
 };
 
@@ -412,6 +564,9 @@ export const ParagraphLargeLineHeight: Story = {
   },
   decorators: [LargeLineHeightDecorator],
   globals: {
+    dir: 'ltr',
+    lang: 'nl',
+    storyRootClassname: 'voorbeeld-theme voorbeeld-theme--overrides',
     viewport: { value: 'wcag100' },
   },
   parameters: {
@@ -427,6 +582,18 @@ In CSS kun je dat simuleren door \`:root { line-height: 3 }\`.`,
     status: {
       type: [],
     },
+    wcagAudit: {
+      author: 'Rian Rietveld',
+      date: '2024-12-12',
+      pass: [
+        WCAG22_131_INFO_AND_RELATIONSHIPS,
+        WCAG22_1410_REFLOW,
+        WCAG22_1412_TEXT_SPACING,
+        WCAG22_143_CONTRAST_MINIMUM,
+        WCAG22_144_RESIZE_TEXT,
+        WCAG22_312_LANGUAGE_OF_PARTS,
+      ],
+    },
   },
 };
 
@@ -437,6 +604,8 @@ export const ParagraphLargeLetterAndWordSpacing: Story = {
   },
   decorators: [LargeLetterSpacingDecorator, LargeWordSpacingDecorator],
   globals: {
+    dir: 'ltr',
+    lang: 'nl',
     viewport: { value: 'wcag100' },
   },
   parameters: {
@@ -451,6 +620,18 @@ In CSS kun je dat simuleren door \`letter-spacing: 0.12em;\` en \`word-spacing: 
     },
     status: {
       type: [],
+    },
+    wcagAudit: {
+      author: 'Rian Rietveld',
+      date: '2025-12-12',
+      pass: [
+        WCAG22_131_INFO_AND_RELATIONSHIPS,
+        WCAG22_1410_REFLOW,
+        WCAG22_1412_TEXT_SPACING,
+        WCAG22_143_CONTRAST_MINIMUM,
+        WCAG22_144_RESIZE_TEXT,
+        WCAG22_312_LANGUAGE_OF_PARTS,
+      ],
     },
   },
 };

--- a/packages/storybook/stories/paragraph.stories.tsx
+++ b/packages/storybook/stories/paragraph.stories.tsx
@@ -39,6 +39,10 @@ export const Default: Story = {
     children: 'Op brute wĳze ving de schooljuf de quasi-kalme lynx.',
     purpose: undefined,
   },
+  globals: {
+    dir: 'ltr',
+    lang: 'nl',
+  },
 };
 
 export const Lead: Story = {
@@ -46,5 +50,9 @@ export const Lead: Story = {
   args: {
     children: 'Op brute wĳze ving de schooljuf de quasi-kalme lynx.',
     purpose: 'lead',
+  },
+  globals: {
+    dir: 'ltr',
+    lang: 'nl',
   },
 };


### PR DESCRIPTION
Er zijn links nu losse URLs waar je stories kan testen, zoals bijvoorbeeld:

- https://candidate-storybook-test-git-docs-wcag-links-nl-design-system.vercel.app/iframe.html?id=componenten-paragraph--paragraph-lead-arabic&args=&globals=&viewMode=story

Deze pagina's hebben nu `<html lang=".." dir="..."><head><title>...</title>` zodat ook Language of the Page and Page Titled succesvol getest kunnen worden.

Elke story kan nu een eigen toegankelijkheidsverklaring hebben, door een `wcagAudit` onder de `parameters` van een Story. Die wordt samengevoegd met de `wcagAudit` van de `meta`, zodat je niet alles bij elke test hoeft te herhalen.

De audit bij een Story kan een eigen tester hebben, met een eigen testdatum.


Algemeen gedeelte:

<img width="1031" alt="Screenshot 2024-12-16 at 00 01 38" src="https://github.com/user-attachments/assets/4f0424b2-5518-4855-bee4-e5253189a158" />

Per Story:

<img width="976" alt="Screenshot 2024-12-15 at 23 59 04" src="https://github.com/user-attachments/assets/b2776b2a-9e45-41a3-bdf0-439f99027cdb" />
