### PR TITLE
docs: improve story descriptions for Color Sample

### DIFF
--- a/packages/storybook-non-conforming/package.json
+++ b/packages/storybook-non-conforming/package.json
@@ -21,7 +21,7 @@
     "@nl-design-system-candidate/storybook-shared": "workspace:*",
     "@nl-design-system-unstable/design-tokens-table-react": "1.0.0",
     "@nl-design-system-unstable/tokens-lib": "0.1.0",
-    "@nl-design-system-unstable/voorbeeld-design-tokens": "3.3.0",
+    "@nl-design-system-unstable/voorbeeld-design-tokens": "3.3.3",
     "@storybook/addon-a11y": "8.4.5",
     "@storybook/addon-controls": "8.4.5",
     "@storybook/addon-docs": "8.4.5",

--- a/packages/storybook-test/package.json
+++ b/packages/storybook-test/package.json
@@ -21,7 +21,7 @@
     "@nl-design-system-candidate/storybook-shared": "workspace:*",
     "@nl-design-system-unstable/design-tokens-table-react": "1.0.0",
     "@nl-design-system-unstable/tokens-lib": "0.1.0",
-    "@nl-design-system-unstable/voorbeeld-design-tokens": "3.3.0",
+    "@nl-design-system-unstable/voorbeeld-design-tokens": "3.3.3",
     "@storybook/addon-a11y": "8.4.5",
     "@storybook/addon-controls": "8.4.5",
     "@storybook/addon-docs": "8.4.5",

--- a/packages/storybook-test/stories/color-sample/color-sample.stories.tsx
+++ b/packages/storybook-test/stories/color-sample/color-sample.stories.tsx
@@ -52,7 +52,9 @@ export const Default: Story = {
     ariaLabelledBy: 'De kleur "lintblauw".',
     docs: {
       description: {
-        story: 'Een kleurstaal met beschrijving voor een doelgroep die gewend is met kleurcodes te werken.',
+        story: `Een kleurstaal met beschrijving voor een doelgroep die gewend is met kleurcodes te werken.
+
+De Color Sample en de tekst staan in dezelfde Paragraph, dus het is duidelijk dat ze bij elkaar horen.`,
       },
     },
     status: { type: [] },
@@ -61,11 +63,41 @@ export const Default: Story = {
     const id = useId();
 
     return (
-      <>
-        <ColorSample {...props} aria-labelledby={id} />
-        <Paragraph id={id}>{context.parameters['ariaLabelledBy']}</Paragraph>
-      </>
+      <Paragraph>
+        <ColorSample {...props} aria-labelledby={id} /> <span id={id}>{context.parameters['ariaLabelledBy']}</span>
+      </Paragraph>
     );
+  },
+};
+
+export const SoloColorSample: Story = {
+  name: 'Color Sample als zelfstandige afbeelding met toegankelijke naam',
+  args: {
+    ['aria-label']: 'De kleur "#154273".',
+    value: '#154273',
+  },
+  decorators: [
+    (Story, context) => (
+      <>
+        <Paragraph>{Story()}</Paragraph>
+        <Paragraph> {context.args['aria-label']}</Paragraph>
+      </>
+    ),
+    ...meta.decorators,
+  ],
+  globals: {
+    dir: 'ltr',
+    lang: 'nl',
+    title: 'De kleur "#154273".',
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Een kleurstaal met expliciete beschrijving in een `aria-label` attribuut, die helemaal los staat in een element staat die bedoeld is om gerelateerde inhoud te groeperen, zoals een Paragraph, Table Cell of List Item. Deze vorm mag alleen gebruikt worden als de kleur elders in de context toegelicht is.',
+      },
+    },
+    status: { type: [] },
   },
 };
 
@@ -91,10 +123,9 @@ export const White: Story = {
     const id = useId();
 
     return (
-      <>
-        <ColorSample {...props} aria-labelledby={id} />
-        <Paragraph id={id}>{context.parameters['ariaLabelledBy']}</Paragraph>
-      </>
+      <Paragraph>
+        <ColorSample {...props} aria-labelledby={id} /> <span id={id}>{context.parameters['ariaLabelledBy']}</span>
+      </Paragraph>
     );
   },
 };
@@ -120,10 +151,9 @@ export const Black: Story = {
     const id = useId();
 
     return (
-      <>
-        <ColorSample {...props} aria-labelledby={id} />
-        <Paragraph id={id}>{context.parameters['ariaLabelledBy']}</Paragraph>
-      </>
+      <Paragraph>
+        <ColorSample {...props} aria-labelledby={id} /> <span id={id}>{context.parameters['ariaLabelledBy']}</span>
+      </Paragraph>
     );
   },
 };
@@ -148,10 +178,37 @@ export const CssColorCode: Story = {
     const id = useId();
 
     return (
-      <>
-        <ColorSample {...props} aria-labelledby={id} />
-        <Paragraph id={id}>{context.parameters['ariaLabelledBy']}</Paragraph>
-      </>
+      <Paragraph>
+        <ColorSample {...props} aria-labelledby={id} /> <span id={id}>{context.parameters['ariaLabelledBy']}</span>
+      </Paragraph>
+    );
+  },
+};
+
+export const TransparentColorSample: Story = {
+  name: 'Color Sample met een 100% transparante kleur',
+  args: { value: '#ffffff00' },
+  globals: {
+    dir: 'ltr',
+    lang: 'nl',
+  },
+  parameters: {
+    ariaLabelledBy: 'De 100% transparante kleur "#ffffff00".',
+    docs: {
+      description: {
+        story:
+          'Een kleurstaal met een 100% transparante kleur en beschrijving, voor een doelgroep die gewend is [alpha-transparantie](https://en.wikipedia.org/wiki/Alpha_compositing) te beoordelen met een checkerboard pattern. De 8-cijferige hexadecimale kleurcode maakt ook duidelijk dat er transparantie is.',
+      },
+    },
+    status: { type: [] },
+  },
+  render(props, context) {
+    const id = useId();
+
+    return (
+      <Paragraph>
+        <ColorSample {...props} aria-labelledby={id} /> <span id={id}>{context.parameters['ariaLabelledBy']}</span>
+      </Paragraph>
     );
   },
 };
@@ -177,33 +234,10 @@ export const SemiTransparentColorSample: Story = {
     const id = useId();
 
     return (
-      <>
-        <ColorSample {...props} aria-labelledby={id} />
-        <Paragraph id={id}>{context.parameters['ariaLabelledBy']}</Paragraph>
-      </>
+      <Paragraph>
+        <ColorSample {...props} aria-labelledby={id} /> <span id={id}>{context.parameters['ariaLabelledBy']}</span>
+      </Paragraph>
     );
-  },
-};
-
-export const SoloColorSample: Story = {
-  name: 'Color Sample als afbeelding met toegankelijke naam',
-  args: {
-    ['aria-label']: 'De kleur "#ff1493".',
-    value: '#ff1493',
-  },
-  globals: {
-    dir: 'ltr',
-    lang: 'nl',
-    title: 'De kleur "#ff1493".',
-  },
-  parameters: {
-    docs: {
-      description: {
-        story:
-          'Een kleurstaal zonder expliciete beschrijving. Deze vorm mag alleen gebruikt worden als de kleur elders in de context toegelicht is.',
-      },
-    },
-    status: { type: [] },
   },
 };
 
@@ -229,10 +263,9 @@ export const Arabic: Story = {
     const id = useId();
 
     return (
-      <>
-        <ColorSample {...props} aria-labelledby={id} />
-        <Paragraph id={id}>{context.parameters['ariaLabelledBy']}</Paragraph>
-      </>
+      <Paragraph>
+        <ColorSample {...props} aria-labelledby={id} /> <span id={id}>{context.parameters['ariaLabelledBy']}</span>
+      </Paragraph>
     );
   },
 };
@@ -260,10 +293,9 @@ export const Japanese: Story = {
     const id = useId();
 
     return (
-      <>
-        <ColorSample {...props} aria-labelledby={id} />
-        <Paragraph id={id}>{context.parameters['ariaLabelledBy']}</Paragraph>
-      </>
+      <Paragraph>
+        <ColorSample {...props} aria-labelledby={id} /> <span id={id}>{context.parameters['ariaLabelledBy']}</span>
+      </Paragraph>
     );
   },
 };

--- a/packages/storybook-test/stories/color-sample/color-sample.stories.tsx
+++ b/packages/storybook-test/stories/color-sample/color-sample.stories.tsx
@@ -68,6 +68,66 @@ export const Default: Story = {
     );
   },
 };
+
+export const White: Story = {
+  name: 'Color Sample voor de kleur wit',
+  args: { value: '#FFFFFF' },
+  globals: {
+    dir: 'ltr',
+    lang: 'nl',
+    title: 'Huisstijlkleuren',
+  },
+  parameters: {
+    ariaLabelledBy: 'De kleur "wit".',
+    docs: {
+      description: {
+        story:
+          'Een kleurstaal met voor de kleur "wit". De kleurstaal is te herkennen op een lichte achtergrondkleur door een border-color met voldoende contrast.',
+      },
+    },
+    status: { type: [] },
+  },
+  render(props, context) {
+    const id = useId();
+
+    return (
+      <>
+        <ColorSample {...props} aria-labelledby={id} />
+        <Paragraph id={id}>{context.parameters['ariaLabelledBy']}</Paragraph>
+      </>
+    );
+  },
+};
+
+export const Black: Story = {
+  name: 'Color Sample voor de kleur zwart',
+  args: { value: '#000000' },
+  globals: {
+    dir: 'ltr',
+    lang: 'nl',
+    title: 'Huisstijlkleuren',
+  },
+  parameters: {
+    ariaLabelledBy: 'De kleur "zwart".',
+    docs: {
+      description: {
+        story: 'Een kleurstaal met voor de kleur "zwart".',
+      },
+    },
+    status: { type: [] },
+  },
+  render(props, context) {
+    const id = useId();
+
+    return (
+      <>
+        <ColorSample {...props} aria-labelledby={id} />
+        <Paragraph id={id}>{context.parameters['ariaLabelledBy']}</Paragraph>
+      </>
+    );
+  },
+};
+
 export const CssColorCode: Story = {
   name: 'Color Sample voor CSS-kleurcode van "deep pink"',
   args: { value: '#ff1493' },

--- a/packages/storybook-test/stories/color-sample/color-sample.stories.tsx
+++ b/packages/storybook-test/stories/color-sample/color-sample.stories.tsx
@@ -41,7 +41,35 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
-  name: 'Color Sample voor "deep pink"',
+  name: 'Color Sample voor een huisstijlkleur',
+  args: { value: '#154273' },
+  globals: {
+    dir: 'ltr',
+    lang: 'nl',
+    title: 'Huisstijlkleuren',
+  },
+  parameters: {
+    ariaLabelledBy: 'De kleur "lintblauw".',
+    docs: {
+      description: {
+        story: 'Een kleurstaal met beschrijving voor een doelgroep die gewend is met kleurcodes te werken.',
+      },
+    },
+    status: { type: [] },
+  },
+  render(props, context) {
+    const id = useId();
+
+    return (
+      <>
+        <ColorSample {...props} aria-labelledby={id} />
+        <Paragraph id={id}>{context.parameters['ariaLabelledBy']}</Paragraph>
+      </>
+    );
+  },
+};
+export const CssColorCode: Story = {
+  name: 'Color Sample voor CSS-kleurcode van "deep pink"',
   args: { value: '#ff1493' },
   globals: {
     dir: 'ltr',

--- a/packages/storybook-test/stories/color-sample/color-sample.stories.tsx
+++ b/packages/storybook-test/stories/color-sample/color-sample.stories.tsx
@@ -51,7 +51,7 @@ export const Default: Story = {
     ariaLabelledBy: 'De kleur "#ff1493".',
     docs: {
       description: {
-        story: 'Een kleurstaal met beschrijving.',
+        story: 'Een kleurstaal met beschrijving voor een doelgroep die gewend is met kleurcodes te werken.',
       },
     },
     status: { type: [] },
@@ -79,7 +79,8 @@ export const SemiTransparentColorSample: Story = {
     ariaLabelledBy: 'De semi-transparante kleur "#ff14937f".',
     docs: {
       description: {
-        story: 'Een kleurstaal met een semitransparante kleur en beschrijving.',
+        story:
+          'Een kleurstaal met een semitransparante kleur en beschrijving, voor een doelgroep die gewend is [alpha-transparantie](https://en.wikipedia.org/wiki/Alpha_compositing) te beoordelen met een checkerboard pattern. De 8-cijferige hexadecimale kleurcode maakt ook duidelijk dat er transparantie is.',
       },
     },
     status: { type: [] },
@@ -129,7 +130,8 @@ export const Arabic: Story = {
     ariaLabelledBy: 'أخضر',
     docs: {
       description: {
-        story: 'Een kleurstaal met beschrijving in Arabisch.',
+        story:
+          'Een kleurstaal met beschrijving in Arabisch, voor de kleur groen (["أخضر" in Arabisch](https://ar.wikipedia.org/wiki/أخضر)).',
       },
     },
     status: { type: [] },
@@ -159,7 +161,8 @@ export const Japanese: Story = {
     ariaLabelledBy: '緑',
     docs: {
       description: {
-        story: 'Een kleurstaal met beschrijving in het Japans.',
+        story:
+          'Een kleurstaal met beschrijving in het Japans, voor de kleur groen (["緑" in Japans](https://ja.wikipedia.org/wiki/緑)).',
       },
     },
     status: { type: [] },

--- a/packages/storybook-test/stories/color-sample/color-sample.stories.tsx
+++ b/packages/storybook-test/stories/color-sample/color-sample.stories.tsx
@@ -188,12 +188,13 @@ export const SemiTransparentColorSample: Story = {
 export const SoloColorSample: Story = {
   name: 'Color Sample als afbeelding met toegankelijke naam',
   args: {
-    title: 'De kleur "#ff1493".',
+    ['aria-label']: 'De kleur "#ff1493".',
     value: '#ff1493',
   },
   globals: {
     dir: 'ltr',
     lang: 'nl',
+    title: 'De kleur "#ff1493".',
   },
   parameters: {
     docs: {

--- a/packages/storybook/package.json
+++ b/packages/storybook/package.json
@@ -23,7 +23,7 @@
     "@fontsource/fira-sans": "5.1.0",
     "@fontsource/source-serif-pro": "5.1.0",
     "@nl-design-system-candidate/storybook-shared": "workspace:*",
-    "@nl-design-system-unstable/voorbeeld-design-tokens": "3.3.0",
+    "@nl-design-system-unstable/voorbeeld-design-tokens": "3.3.3",
     "@storybook/addon-a11y": "8.4.5",
     "@storybook/addon-actions": "8.4.5",
     "@storybook/addon-docs": "8.4.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -498,8 +498,8 @@ importers:
         specifier: workspace:*
         version: link:../storybook-shared
       '@nl-design-system-unstable/voorbeeld-design-tokens':
-        specifier: 3.3.0
-        version: 3.3.0
+        specifier: 3.3.3
+        version: 3.3.3
       '@storybook/addon-a11y':
         specifier: 8.4.5
         version: 8.4.5(storybook@8.4.5(prettier@3.3.3))
@@ -576,8 +576,8 @@ importers:
         specifier: 0.1.0
         version: 0.1.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.4.5(prettier@3.3.3))
       '@nl-design-system-unstable/voorbeeld-design-tokens':
-        specifier: 3.3.0
-        version: 3.3.0
+        specifier: 3.3.3
+        version: 3.3.3
       '@storybook/addon-a11y':
         specifier: 8.4.5
         version: 8.4.5(storybook@8.4.5(prettier@3.3.3))
@@ -681,8 +681,8 @@ importers:
         specifier: 0.1.0
         version: 0.1.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.4.5(prettier@3.3.3))
       '@nl-design-system-unstable/voorbeeld-design-tokens':
-        specifier: 3.3.0
-        version: 3.3.0
+        specifier: 3.3.3
+        version: 3.3.3
       '@storybook/addon-a11y':
         specifier: 8.4.5
         version: 8.4.5(storybook@8.4.5(prettier@3.3.3))
@@ -1916,8 +1916,8 @@ packages:
   '@nl-design-system-unstable/tokens-lib@0.1.0':
     resolution: {integrity: sha512-KppSSPf5gNUeKwysRFYJDvF5k17h1Zp5szjrR8HfSwOWP3JnGjfyk9IeuvdiH4NbR2KwIfcvYvSoMGVvXBuvFA==}
 
-  '@nl-design-system-unstable/voorbeeld-design-tokens@3.3.0':
-    resolution: {integrity: sha512-ouUbcwlBMt0KHAhbpGGgllUk+knjbP1ijvfVfCIR3xw1eTZvPC+eo3JT/fb+61dcW670xbw3+C121PRfs/u8UA==}
+  '@nl-design-system-unstable/voorbeeld-design-tokens@3.3.3':
+    resolution: {integrity: sha512-r5TbUUapFwQI0SSFLBdbiF1qE+YjlV7haBKv3i3Y+PMkuEpo51l2lRRYEeuo0P11S8zjg+VQZLcERIO0fqf6BA==}
 
   '@nl-design-system/eslint-config@0.0.1':
     resolution: {integrity: sha512-zgKEBk0S88bkRX4zRihhoOidQtekpvOHWOOPl0aJhTy5aF2hyFzbzDTGjPgpseo0lDbwZjd7LUwLJevOj83WYg==}
@@ -7639,7 +7639,7 @@ snapshots:
       - react-dom
       - storybook
 
-  '@nl-design-system-unstable/voorbeeld-design-tokens@3.3.0': {}
+  '@nl-design-system-unstable/voorbeeld-design-tokens@3.3.3': {}
 
   '@nl-design-system/eslint-config@0.0.1(eslint@9.14.0)(typescript@5.6.3)':
     dependencies:


### PR DESCRIPTION
- [x] Door toevoegen linkjes naar Wikipedia is het makkelijker om te beoordelen of de kleurnamen in een andere taal kloppen.
- [x] Duidelijk maken dat de checkerboard pattern en hex-kleurcodes voor een professionele doelgroep is, die het gewend zijn en begrijpen wat het betekent.
- [x] updaten van Voorbeeld thema voor beter contrast van de border, nadat [deze PR](https://github.com/nl-design-system/themes/pull/878) is gemerged en de release PR is gemerged
- [x] Story toevoegen voor lichte kleur