### PR TITLE
chore: update codecov/codecov-action

### DIFF
--- a/.github/workflows/continuous-deployment.yml
+++ b/.github/workflows/continuous-deployment.yml
@@ -118,7 +118,7 @@ jobs:
         run: pnpm run test:coverage
 
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@015f24e6818733317a2da2edd6290ab26238649a # v4.0.1
+        uses: codecov/codecov-action@1e68e06f1dbfde0e4cefc87efeba9e4643565303 # v5.1.2
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
 


### PR DESCRIPTION
Correct the version number in the comment as well, this was suggesting v4.0.1 but was in fact v5.0.7

Replaces #420 