### PR TITLE
fix: Verplaats het aria-label op de link naar de SVG en voeg de ontbrekende aria-current toe

### DIFF
--- a/packages/storybook-test/stories/link/link.stories.tsx
+++ b/packages/storybook-test/stories/link/link.stories.tsx
@@ -340,7 +340,7 @@ export const Current: Story = {
 export const inlineBox: Story = {
   name: 'Link rondom image',
   args: {
-    'aria-label': 'homepage · NL Design System',
+    'aria-label': 'NL Design System logo, naar de voorpagina',
     children: <ExampleImage />,
     href: 'https://nldesignsystem.nl/',
     inlineBox: true,
@@ -364,7 +364,7 @@ export const inlineBox: Story = {
 export const inlineBoxHover: Story = {
   name: 'Link rondom image met :hover',
   args: {
-    'aria-label': 'homepage · NL Design System',
+    'aria-label': 'NL Design System logo, naar de voorpagina',
     children: <ExampleImage />,
     className: 'nl-link--hover',
     href: 'https://nldesignsystem.nl/',
@@ -389,7 +389,8 @@ export const inlineBoxHover: Story = {
 export const inlineBoxCurrent: Story = {
   name: 'Link rondom image, current page',
   args: {
-    'aria-label': 'homepage · NL Design System',
+    'aria-current': 'true',
+    'aria-label': 'NL Design System logo, naar de voorpagina',
     children: <ExampleImage />,
     href: 'https://nldesignsystem.nl/',
     inlineBox: true,

--- a/packages/storybook-test/stories/link/link.stories.tsx
+++ b/packages/storybook-test/stories/link/link.stories.tsx
@@ -12,7 +12,7 @@ import '../../../components-css/link-css/src/test.scss';
 const ExampleImage = () => (
   <svg
     role="img"
-    aria-label="NL Design System logo"
+    aria-label="NL Design System logo, naar de voorpagina"
     width="420"
     height="auto"
     viewBox="0 0 1120 630"
@@ -340,7 +340,6 @@ export const Current: Story = {
 export const inlineBox: Story = {
   name: 'Link rondom image',
   args: {
-    'aria-label': 'NL Design System logo, naar de voorpagina',
     children: <ExampleImage />,
     href: 'https://nldesignsystem.nl/',
     inlineBox: true,
@@ -364,7 +363,6 @@ export const inlineBox: Story = {
 export const inlineBoxHover: Story = {
   name: 'Link rondom image met :hover',
   args: {
-    'aria-label': 'NL Design System logo, naar de voorpagina',
     children: <ExampleImage />,
     className: 'nl-link--hover',
     href: 'https://nldesignsystem.nl/',
@@ -390,7 +388,6 @@ export const inlineBoxCurrent: Story = {
   name: 'Link rondom image, current page',
   args: {
     'aria-current': 'true',
-    'aria-label': 'NL Design System logo, naar de voorpagina',
     children: <ExampleImage />,
     href: 'https://nldesignsystem.nl/',
     inlineBox: true,


### PR DESCRIPTION
Best practice is om de toegankelijke naam van een link te beginnen met de visuele tekst. De dot in de tekst is overbodig, gebruik voor een korte pauze beter een komma.

De `aria-current` ontbrak op de link voor het verhaal “Link rondom image, current page” en is nu toegevoegd.

De toegankelijke naam staat op de SVG.
Vergelijkbaar met het geval van een img met een alt attribuut.
ZIe voor uitleg: https://www.htmhell.dev/adventcalendar/2024/1/

Preview: https://candidate-storybook-test-git-fix-logo-i-ae48c3-nl-design-system.vercel.app/?path=/docs/componenten-link--documentatie
Gerelateerd issue: https://github.com/nl-design-system/candidate/issues/210
