### PR TITLE
fix: provenance

### DIFF
--- a/.github/workflows/changeset-status.yml
+++ b/.github/workflows/changeset-status.yml
@@ -1,6 +1,9 @@
 name: Changeset status
 
-on: pull_request
+on:
+  pull_request:
+    branches_ignore:
+      - changeset-release/*
 
 jobs:
   changeset-status:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,6 +7,7 @@ on:
 permissions:
   contents: read # since GH_TOKEN is provided, we only need 'read'
   pull-requests: write # Needed to create and update pull requests
+  id-token: write # https://docs.npmjs.com/generating-provenance-statements#publishing-packages-with-provenance-via-github-actions
 
 jobs:
   publish:


### PR DESCRIPTION
Provenance needs `id-token: write`

Skip the changeset-status workflow for the nl-design-system-ci actor