### PR TITLE
fix: conditionally run changeset-status

### DIFF
--- a/.github/workflows/changeset-status.yml
+++ b/.github/workflows/changeset-status.yml
@@ -1,13 +1,11 @@
 name: Changeset status
 
-on:
-  pull_request:
-    branches_ignore:
-      - changeset-release/*
+on: pull_request
 
 jobs:
   changeset-status:
     runs-on: ubuntu-latest
+    if: ${{ ! startsWith(github.head_ref, 'changeset-release/') }}
     steps:
       - name: Create GitHub App Token
         id: app-token


### PR DESCRIPTION
Only run changeset-status if the branch being merged does not start with `changeset-release/`