### PR TITLE
chore: provenance components-css

### DIFF
--- a/.changeset/beige-owls-play.md
+++ b/.changeset/beige-owls-play.md
@@ -1,0 +1,20 @@
+---
+'@nl-design-system-candidate/color-sample-css': patch
+'@nl-design-system-candidate/number-badge-css': patch
+'@nl-design-system-candidate/code-block-css': patch
+'@nl-design-system-candidate/data-badge-css': patch
+'@nl-design-system-candidate/heading-1-css': patch
+'@nl-design-system-candidate/heading-2-css': patch
+'@nl-design-system-candidate/heading-3-css': patch
+'@nl-design-system-candidate/heading-4-css': patch
+'@nl-design-system-candidate/heading-5-css': patch
+'@nl-design-system-candidate/heading-6-css': patch
+'@nl-design-system-candidate/paragraph-css': patch
+'@nl-design-system-candidate/skip-link-css': patch
+'@nl-design-system-candidate/heading-css': patch
+'@nl-design-system-candidate/code-css': patch
+'@nl-design-system-candidate/link-css': patch
+'@nl-design-system-candidate/mark-css': patch
+---
+
+Add provenance

--- a/packages/components-css/code-block-css/package.json
+++ b/packages/components-css/code-block-css/package.json
@@ -18,7 +18,8 @@
     "directory": "packages/components-css/code-block-css"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "scripts": {
     "build": "sass ./src/:./dist/",

--- a/packages/components-css/code-css/package.json
+++ b/packages/components-css/code-css/package.json
@@ -18,7 +18,8 @@
     "directory": "packages/components-css/code-css"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "scripts": {
     "build": "sass ./src/:./dist/",

--- a/packages/components-css/color-sample-css/package.json
+++ b/packages/components-css/color-sample-css/package.json
@@ -18,7 +18,8 @@
     "directory": "packages/components-css/color-sample-css"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "scripts": {
     "build": "sass ./src/:./dist/",

--- a/packages/components-css/data-badge-css/package.json
+++ b/packages/components-css/data-badge-css/package.json
@@ -18,7 +18,8 @@
     "directory": "packages/components-css/data-badge-css"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "scripts": {
     "build": "sass ./src/:./dist/",

--- a/packages/components-css/heading-1-css/package.json
+++ b/packages/components-css/heading-1-css/package.json
@@ -19,7 +19,8 @@
   },
   "private": true,
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "scripts": {
     "build": "sass ./src/:./dist/",

--- a/packages/components-css/heading-2-css/package.json
+++ b/packages/components-css/heading-2-css/package.json
@@ -19,7 +19,8 @@
   },
   "private": true,
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "scripts": {
     "build": "sass ./src/:./dist/",

--- a/packages/components-css/heading-3-css/package.json
+++ b/packages/components-css/heading-3-css/package.json
@@ -19,7 +19,8 @@
   },
   "private": true,
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "scripts": {
     "build": "sass ./src/:./dist/",

--- a/packages/components-css/heading-4-css/package.json
+++ b/packages/components-css/heading-4-css/package.json
@@ -19,7 +19,8 @@
   },
   "private": true,
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "scripts": {
     "build": "sass ./src/:./dist/",

--- a/packages/components-css/heading-5-css/package.json
+++ b/packages/components-css/heading-5-css/package.json
@@ -19,7 +19,8 @@
   },
   "private": true,
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "scripts": {
     "build": "sass ./src/:./dist/",

--- a/packages/components-css/heading-6-css/package.json
+++ b/packages/components-css/heading-6-css/package.json
@@ -19,7 +19,8 @@
   },
   "private": true,
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "scripts": {
     "build": "sass ./src/:./dist/",

--- a/packages/components-css/heading-css/package.json
+++ b/packages/components-css/heading-css/package.json
@@ -18,7 +18,8 @@
     "directory": "packages/components-css/heading-css"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "scripts": {
     "build": "sass ./src/:./dist/",

--- a/packages/components-css/link-css/package.json
+++ b/packages/components-css/link-css/package.json
@@ -18,7 +18,8 @@
     "directory": "packages/components-css/link-css"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "scripts": {
     "build": "sass ./src/:./dist/",

--- a/packages/components-css/mark-css/package.json
+++ b/packages/components-css/mark-css/package.json
@@ -18,7 +18,8 @@
     "directory": "packages/components-css/mark-css"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "scripts": {
     "build": "sass ./src/:./dist/",

--- a/packages/components-css/number-badge-css/package.json
+++ b/packages/components-css/number-badge-css/package.json
@@ -18,7 +18,8 @@
     "directory": "packages/components-css/number-badge-css"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "scripts": {
     "build": "sass ./src/:./dist/",

--- a/packages/components-css/paragraph-css/package.json
+++ b/packages/components-css/paragraph-css/package.json
@@ -18,7 +18,8 @@
     "directory": "packages/components-css/paragraph-css"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "scripts": {
     "build": "sass ./src/:./dist/",

--- a/packages/components-css/skip-link-css/package.json
+++ b/packages/components-css/skip-link-css/package.json
@@ -18,7 +18,8 @@
     "directory": "packages/components-css/skip-link-css"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "scripts": {
     "build": "sass ./src/:./dist/",


### PR DESCRIPTION
Met de gefixte workflow zou er na het mergen van deze PR een PR geopend moeten worden die niet ten onrechte geflagged wordt door de changeset-status workflow.