### PR TITLE
Update tokens

### DIFF
--- a/.changeset/dirty-squids-behave.md
+++ b/.changeset/dirty-squids-behave.md
@@ -1,0 +1,5 @@
+---
+'@nl-design-system-candidate/code-block-tokens': major
+---
+
+`$type` for `nl.code-block.border-radius` has changed from `borderRadius` to `dimension` to align with the W3C DTCG specification.

--- a/.changeset/few-knives-begin.md
+++ b/.changeset/few-knives-begin.md
@@ -1,0 +1,5 @@
+---
+'@nl-design-system-candidate/mark-tokens': major
+---
+
+`$extensions` now uses `nl.nldesignsystem.css-property-syntax` instead of the nested `nl.nldesignsystem.css-property` and `nl.nldesignsystem.figma-implementation` instead of `nl.nldesignsystem.figma-available` for both the `nl.mark.background-color` and `nl.mark.color` tokens.

--- a/.changeset/funny-insects-jump.md
+++ b/.changeset/funny-insects-jump.md
@@ -1,0 +1,5 @@
+---
+'@nl-design-system-candidate/data-badge-tokens': major
+---
+
+`$type` for `nl.data-badge.border-radius` and `nl.data-badge.border-width` has changed from respectively `borderRadius` and `borderWidth` to `dimension` to align with the W3C DTCG specification.

--- a/.changeset/kind-flowers-listen.md
+++ b/.changeset/kind-flowers-listen.md
@@ -1,0 +1,14 @@
+---
+'@nl-design-system-candidate/color-sample-tokens': patch
+'@nl-design-system-candidate/number-badge-tokens': patch
+'@nl-design-system-candidate/code-block-tokens': patch
+'@nl-design-system-candidate/data-badge-tokens': patch
+'@nl-design-system-candidate/paragraph-tokens': patch
+'@nl-design-system-candidate/skip-link-tokens': patch
+'@nl-design-system-candidate/heading-tokens': patch
+'@nl-design-system-candidate/code-tokens': patch
+'@nl-design-system-candidate/link-tokens': patch
+'@nl-design-system-candidate/mark-tokens': patch
+---
+
+Add provenance

--- a/.changeset/lazy-cherries-march.md
+++ b/.changeset/lazy-cherries-march.md
@@ -1,0 +1,5 @@
+---
+'@nl-design-system-candidate/number-badge-tokens': major
+---
+
+`$type` for `nl.number-badge.border-radius` and `nl.number-badge-border-width` has changed from respectively `borderRadius` and `borderWidth` to `dimension` to align with the W3C DTCG specification.

--- a/.changeset/silver-rats-protect.md
+++ b/.changeset/silver-rats-protect.md
@@ -1,0 +1,6 @@
+---
+'@nl-design-system-candidate/link-tokens': major
+---
+
+The `nl.link.current.font-weight` token was removed.
+The `nl.link.disabled.font-weight` token was removed.

--- a/.changeset/swift-eyes-hide.md
+++ b/.changeset/swift-eyes-hide.md
@@ -1,0 +1,7 @@
+---
+'@nl-design-system-candidate/link-tokens': minor
+---
+
+Add `nl.link.focus-visible.*` tokens. Subject to change as it is likely for these to be moved to common tokens.
+
+Add `nl.link.active.text-decoration-line` and `nl.link.active.text-decoration-thickness` tokens.

--- a/.changeset/wise-feet-cover.md
+++ b/.changeset/wise-feet-cover.md
@@ -1,0 +1,5 @@
+---
+'@nl-design-system-candidate/color-sample-tokens': major
+---
+
+`$type` for `nl.color-sample.border-radius` and `nl.color-sample.border-width` has changed from respectively `borderRadius` and `borderWidth` to `dimension` to align with the W3C DTCG specification.

--- a/packages/tokens/code-block-tokens/package.json
+++ b/packages/tokens/code-block-tokens/package.json
@@ -14,7 +14,8 @@
     "directory": "packages/tokens/code-block-tokens"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "scripts": {
     "generate-tokens": "../../../scripts/generate-tokens.sh code-block"

--- a/packages/tokens/code-block-tokens/package.json
+++ b/packages/tokens/code-block-tokens/package.json
@@ -15,5 +15,8 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "scripts": {
+    "generate-tokens": "../../../scripts/generate-tokens.sh code-block"
   }
 }

--- a/packages/tokens/code-block-tokens/tokens.json
+++ b/packages/tokens/code-block-tokens/tokens.json
@@ -13,7 +13,7 @@
           "nl.nldesignsystem.css-property-syntax": "<length-percentage>",
           "nl.nldesignsystem.figma-implementation": true
         },
-        "$type": "borderRadius"
+        "$type": "dimension"
       },
       "color": {
         "$extensions": {

--- a/packages/tokens/code-tokens/package.json
+++ b/packages/tokens/code-tokens/package.json
@@ -14,7 +14,8 @@
     "directory": "packages/tokens/code-tokens"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "scripts": {
     "generate-tokens": "../../../scripts/generate-tokens.sh code"

--- a/packages/tokens/code-tokens/package.json
+++ b/packages/tokens/code-tokens/package.json
@@ -15,5 +15,8 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "scripts": {
+    "generate-tokens": "../../../scripts/generate-tokens.sh code"
   }
 }

--- a/packages/tokens/color-sample-tokens/package.json
+++ b/packages/tokens/color-sample-tokens/package.json
@@ -14,7 +14,8 @@
     "directory": "packages/tokens/color-sample-tokens"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "scripts": {
     "generate-tokens": "../../../scripts/generate-tokens.sh color-sample"

--- a/packages/tokens/color-sample-tokens/package.json
+++ b/packages/tokens/color-sample-tokens/package.json
@@ -15,5 +15,8 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "scripts": {
+    "generate-tokens": "../../../scripts/generate-tokens.sh color-sample"
   }
 }

--- a/packages/tokens/color-sample-tokens/tokens.json
+++ b/packages/tokens/color-sample-tokens/tokens.json
@@ -27,14 +27,14 @@
           "nl.nldesignsystem.css-property-syntax": "<length-percentage>",
           "nl.nldesignsystem.figma-implementation": true
         },
-        "$type": "borderRadius"
+        "$type": "dimension"
       },
       "border-width": {
         "$extensions": {
           "nl.nldesignsystem.css-property-syntax": "<length>",
           "nl.nldesignsystem.figma-implementation": true
         },
-        "$type": "borderWidth"
+        "$type": "dimension"
       },
       "inline-size": {
         "$extensions": {

--- a/packages/tokens/data-badge-tokens/package.json
+++ b/packages/tokens/data-badge-tokens/package.json
@@ -14,7 +14,8 @@
     "directory": "packages/tokens/data-badge-tokens"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "scripts": {
     "generate-tokens": "../../../scripts/generate-tokens.sh data-badge"

--- a/packages/tokens/data-badge-tokens/package.json
+++ b/packages/tokens/data-badge-tokens/package.json
@@ -15,5 +15,8 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "scripts": {
+    "generate-tokens": "../../../scripts/generate-tokens.sh data-badge"
   }
 }

--- a/packages/tokens/data-badge-tokens/tokens.json
+++ b/packages/tokens/data-badge-tokens/tokens.json
@@ -20,14 +20,14 @@
           "nl.nldesignsystem.css-property-syntax": "<length-percentage>",
           "nl.nldesignsystem.figma-implementation": true
         },
-        "$type": "borderRadius"
+        "$type": "dimension"
       },
       "border-width": {
         "$extensions": {
           "nl.nldesignsystem.css-property-syntax": "<length>",
           "nl.nldesignsystem.figma-implementation": true
         },
-        "$type": "borderWidth"
+        "$type": "dimension"
       },
       "color": {
         "$extensions": {

--- a/packages/tokens/heading-tokens/package.json
+++ b/packages/tokens/heading-tokens/package.json
@@ -14,7 +14,8 @@
     "directory": "packages/tokens/heading-tokens"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "scripts": {
     "generate-tokens": "../../../scripts/generate-tokens.sh heading"

--- a/packages/tokens/heading-tokens/package.json
+++ b/packages/tokens/heading-tokens/package.json
@@ -15,5 +15,8 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "scripts": {
+    "generate-tokens": "../../../scripts/generate-tokens.sh heading"
   }
 }

--- a/packages/tokens/link-tokens/package.json
+++ b/packages/tokens/link-tokens/package.json
@@ -15,5 +15,8 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "scripts": {
+    "generate-tokens": "../../../scripts/generate-tokens.sh link"
   }
 }

--- a/packages/tokens/link-tokens/package.json
+++ b/packages/tokens/link-tokens/package.json
@@ -14,7 +14,8 @@
     "directory": "packages/tokens/link-tokens"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "scripts": {
     "generate-tokens": "../../../scripts/generate-tokens.sh link"

--- a/packages/tokens/link-tokens/tokens.json
+++ b/packages/tokens/link-tokens/tokens.json
@@ -8,6 +8,20 @@
             "nl.nldesignsystem.figma-implementation": true
           },
           "$type": "color"
+        },
+        "text-decoration-line": {
+          "$extensions": {
+            "nl.nldesignsystem.css-property-syntax": ["inherit", "none", "underline"],
+            "nl.nldesignsystem.figma-implementation": true
+          },
+          "$type": "textDecoration"
+        },
+        "text-decoration-thickness": {
+          "$extensions": {
+            "nl.nldesignsystem.css-property-syntax": "<length>",
+            "nl.nldesignsystem.figma-implementation": false
+          },
+          "$type": "other"
         }
       },
       "color": {
@@ -24,13 +38,6 @@
             "nl.nldesignsystem.figma-implementation": false
           },
           "$type": "other"
-        },
-        "font-weight": {
-          "$extensions": {
-            "nl.nldesignsystem.css-property-syntax": "<number>",
-            "nl.nldesignsystem.figma-implementation": false
-          },
-          "$type": "fontWeights"
         }
       },
       "disabled": {
@@ -47,13 +54,36 @@
             "nl.nldesignsystem.figma-implementation": false
           },
           "$type": "other"
-        },
-        "font-weight": {
+        }
+      },
+      "focus-visible": {
+        "background-color": {
           "$extensions": {
-            "nl.nldesignsystem.css-property-syntax": "<number>",
+            "nl.nldesignsystem.css-property-syntax": "<color>",
+            "nl.nldesignsystem.figma-implementation": true
+          },
+          "$type": "color"
+        },
+        "color": {
+          "$extensions": {
+            "nl.nldesignsystem.css-property-syntax": "<color>",
+            "nl.nldesignsystem.figma-implementation": true
+          },
+          "$type": "color"
+        },
+        "text-decoration-line": {
+          "$extensions": {
+            "nl.nldesignsystem.css-property-syntax": ["inherit", "none", "underline"],
+            "nl.nldesignsystem.figma-implementation": true
+          },
+          "$type": "textDecoration"
+        },
+        "text-decoration-thickness": {
+          "$extensions": {
+            "nl.nldesignsystem.css-property-syntax": "<length>",
             "nl.nldesignsystem.figma-implementation": false
           },
-          "$type": "fontWeights"
+          "$type": "other"
         }
       },
       "hover": {
@@ -79,19 +109,19 @@
           "$type": "other"
         }
       },
-      "text-decoration-line": {
-        "$extensions": {
-          "nl.nldesignsystem.css-property-syntax": ["inherit", "none", "underline"],
-          "nl.nldesignsystem.figma-implementation": true
-        },
-        "$type": "textDecoration"
-      },
       "text-decoration-color": {
         "$extensions": {
           "nl.nldesignsystem.css-property-syntax": "<color>",
           "nl.nldesignsystem.figma-implementation": true
         },
         "$type": "color"
+      },
+      "text-decoration-line": {
+        "$extensions": {
+          "nl.nldesignsystem.css-property-syntax": ["inherit", "none", "underline"],
+          "nl.nldesignsystem.figma-implementation": true
+        },
+        "$type": "textDecoration"
       },
       "text-decoration-thickness": {
         "$extensions": {

--- a/packages/tokens/mark-tokens/package.json
+++ b/packages/tokens/mark-tokens/package.json
@@ -12,7 +12,8 @@
     "directory": "packages/tokens/mark-tokens"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "scripts": {
     "generate-tokens": "../../../scripts/generate-tokens.sh mark"

--- a/packages/tokens/mark-tokens/package.json
+++ b/packages/tokens/mark-tokens/package.json
@@ -13,5 +13,8 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "scripts": {
+    "generate-tokens": "../../../scripts/generate-tokens.sh mark"
   }
 }

--- a/packages/tokens/mark-tokens/tokens.json
+++ b/packages/tokens/mark-tokens/tokens.json
@@ -3,21 +3,15 @@
     "mark": {
       "background-color": {
         "$extensions": {
-          "nl.nldesignsystem.css-property": {
-            "inherits": true,
-            "syntax": "<color>"
-          },
-          "nl.nldesignsystem.figma-available": true
+          "nl.nldesignsystem.css-property-syntax": "<color>",
+          "nl.nldesignsystem.figma-implementation": true
         },
         "$type": "color"
       },
       "color": {
         "$extensions": {
-          "nl.nldesignsystem.css-property": {
-            "inherits": true,
-            "syntax": "<color>"
-          },
-          "nl.nldesignsystem.figma-available": true
+          "nl.nldesignsystem.css-property-syntax": "<color>",
+          "nl.nldesignsystem.figma-implementation": true
         },
         "$type": "color"
       }

--- a/packages/tokens/number-badge-tokens/package.json
+++ b/packages/tokens/number-badge-tokens/package.json
@@ -14,7 +14,8 @@
     "directory": "packages/tokens/number-badge-tokens"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "scripts": {
     "generate-tokens": "../../../scripts/generate-tokens.sh number-badge"

--- a/packages/tokens/number-badge-tokens/package.json
+++ b/packages/tokens/number-badge-tokens/package.json
@@ -15,5 +15,8 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "scripts": {
+    "generate-tokens": "../../../scripts/generate-tokens.sh number-badge"
   }
 }

--- a/packages/tokens/number-badge-tokens/tokens.json
+++ b/packages/tokens/number-badge-tokens/tokens.json
@@ -2,88 +2,88 @@
   "nl": {
     "number-badge": {
       "background-color": {
-        "$type": "color",
         "$extensions": {
           "nl.nldesignsystem.css-property-syntax": "<color>",
           "nl.nldesignsystem.figma-implementation": true
-        }
+        },
+        "$type": "color"
       },
       "border-color": {
-        "$type": "color",
         "$extensions": {
           "nl.nldesignsystem.css-property-syntax": "<color>",
           "nl.nldesignsystem.figma-implementation": true
-        }
+        },
+        "$type": "color"
       },
       "border-radius": {
-        "$type": "borderRadius",
         "$extensions": {
           "nl.nldesignsystem.css-property-syntax": "<length-percentage>",
           "nl.nldesignsystem.figma-implementation": true
-        }
+        },
+        "$type": "dimension"
       },
       "border-width": {
-        "$type": "borderWidth",
         "$extensions": {
           "nl.nldesignsystem.css-property-syntax": "<length>",
           "nl.nldesignsystem.figma-implementation": true
-        }
+        },
+        "$type": "dimension"
       },
       "color": {
-        "$type": "color",
         "$extensions": {
           "nl.nldesignsystem.css-property-syntax": "<color>",
           "nl.nldesignsystem.figma-implementation": true
-        }
+        },
+        "$type": "color"
       },
       "font-family": {
-        "$type": "fontFamilies",
         "$extensions": {
           "nl.nldesignsystem.css-property-syntax": ["<family-name>", "<generic-name>"],
           "nl.nldesignsystem.figma-implementation": true
-        }
+        },
+        "$type": "fontFamilies"
       },
       "font-size": {
-        "$type": "fontSizes",
         "$extensions": {
           "nl.nldesignsystem.css-property-syntax": ["<length>", "<percentage>"],
           "nl.nldesignsystem.figma-implementation": true
-        }
+        },
+        "$type": "fontSizes"
       },
       "font-weight": {
-        "$type": "fontWeights",
         "$extensions": {
           "nl.nldesignsystem.css-property-syntax": "<number>",
           "nl.nldesignsystem.figma-implementation": true
-        }
+        },
+        "$type": "fontWeights"
       },
       "min-block-size": {
-        "$type": "dimension",
         "$extensions": {
           "nl.nldesignsystem.css-property-syntax": "<length>",
           "nl.nldesignsystem.figma-implementation": true
-        }
+        },
+        "$type": "dimension"
       },
       "min-inline-size": {
-        "$type": "dimension",
         "$extensions": {
           "nl.nldesignsystem.css-property-syntax": "<length>",
           "nl.nldesignsystem.figma-implementation": true
-        }
+        },
+        "$type": "dimension"
       },
       "padding-block": {
-        "$type": "dimension",
         "$extensions": {
           "nl.nldesignsystem.css-property-syntax": "<length>",
           "nl.nldesignsystem.figma-implementation": true
-        }
+        },
+        "$type": "dimension"
       },
       "padding-inline": {
-        "$type": "dimension",
         "$extensions": {
           "nl.nldesignsystem.css-property-syntax": "<length>",
           "nl.nldesignsystem.figma-implementation": true
-        }
+        },
+        "$type": "dimension"
       }
     }
   }

--- a/packages/tokens/paragraph-tokens/package.json
+++ b/packages/tokens/paragraph-tokens/package.json
@@ -15,5 +15,8 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "scripts": {
+    "generate-tokens": "../../../scripts/generate-tokens.sh paragraph"
   }
 }

--- a/packages/tokens/paragraph-tokens/package.json
+++ b/packages/tokens/paragraph-tokens/package.json
@@ -14,7 +14,8 @@
     "directory": "packages/tokens/paragraph-tokens"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "scripts": {
     "generate-tokens": "../../../scripts/generate-tokens.sh paragraph"

--- a/packages/tokens/skip-link-tokens/package.json
+++ b/packages/tokens/skip-link-tokens/package.json
@@ -15,5 +15,8 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "scripts": {
+    "generate-tokens": "../../../scripts/generate-tokens.sh skip-link"
   }
 }

--- a/packages/tokens/skip-link-tokens/package.json
+++ b/packages/tokens/skip-link-tokens/package.json
@@ -14,7 +14,8 @@
     "directory": "packages/tokens/skip-link-tokens"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "scripts": {
     "generate-tokens": "../../../scripts/generate-tokens.sh skip-link"

--- a/scripts/filter.jq
+++ b/scripts/filter.jq
@@ -1,0 +1,57 @@
+# usage: jq -f filter.jq --arg key "components/component/nl" path/to/tokens.json
+def is_css_property:
+  type == "object" and has("$type");
+
+def insert_property:
+  if type == "object" then
+    to_entries |
+    map(
+      .value |= insert_property |
+      if .value |
+        is_css_property then
+        .value += { "__property": .key }
+      end) |
+    from_entries
+  end;
+
+def insert_extensions:
+  walk(if is_css_property then
+    if ."$type" == "color" then
+      . + { "$extensions": { "nl.nldesignsystem.css-property-syntax": "<color>", "nl.nldesignsystem.figma-implementation": true }}
+    elif ."$type" == "fontFamilies" then
+      . + { "$extensions": { "nl.nldesignsystem.css-property-syntax": ["<family-name>", "<generic-name>"], "nl.nldesignsystem.figma-implementation": true }}
+    elif ."$type" == "lineHeights" then
+      . + { "$extensions": { "nl.nldesignsystem.css-property-syntax": ["<length>", "<number>"], "nl.nldesignsystem.figma-implementation": true }}
+    elif ."$type" == "fontSizes" then
+      . + { "$extensions": { "nl.nldesignsystem.css-property-syntax": ["<length>", "<percentage>"], "nl.nldesignsystem.figma-implementation": true }}
+    elif ."$type" == "fontWeights" then
+      . + { "$extensions": { "nl.nldesignsystem.css-property-syntax": "<number>", "nl.nldesignsystem.figma-implementation": true }}
+    elif ."$type" == "textDecoration" then
+      . + { "$extensions": { "nl.nldesignsystem.css-property-syntax": ["inherit", "none", "underline"], "nl.nldesignsystem.figma-implementation": true }}
+    elif ."$type" == "dimension" then
+      if ."__property" == "border-radius" then
+        . + { "$extensions": { "nl.nldesignsystem.css-property-syntax": "<length-percentage>", "nl.nldesignsystem.figma-implementation": true }}
+      # insert more exceptions for specific dimensions if needed
+      else
+        . + { "$extensions": { "nl.nldesignsystem.css-property-syntax": "<length>", "nl.nldesignsystem.figma-implementation": true }}
+      end
+    elif ."$type" == "other" then
+      if ."__property" == "cursor" then
+        . + { "$extensions": { "nl.nldesignsystem.css-property-syntax": ["<url>", "pointer", "*"], "nl.nldesignsystem.figma-implementation": false }}
+      elif ."__property" == "text-decoration-thickness" then
+        . + { "$extensions": { "nl.nldesignsystem.css-property-syntax": "<length>", "nl.nldesignsystem.figma-implementation": false }}
+      elif ."__property" == "text-underline-offset" then
+        . + { "$extensions": { "nl.nldesignsystem.css-property-syntax": "<length>", "nl.nldesignsystem.figma-implementation": false }}
+      else
+        . + { "$extensions": { "nl.nldesignsystem.css-property-syntax": "<unknown>", "nl.nldesignsystem.figma-implementation": false }}
+      end
+    end
+  end);
+
+def remove_property_and_value:
+  walk(if is_css_property then del(."__property") | del(."$value") end);
+
+{ "nl": .[$key].nl } |
+insert_property |
+insert_extensions |
+remove_property_and_value

--- a/scripts/generate-tokens.sh
+++ b/scripts/generate-tokens.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_name="${BASH_SOURCE[0]##*/}"
+script_path="${BASH_SOURCE[0]%/*}"
+
+if [ -z "${1-}" ]; then
+  printf "%s\n\n" "Usage: ${script_name} <component>"
+  exit 1
+fi
+
+if [ ! -e "${script_path}/filter.jq" ]; then
+  printf "%s\n\n" "filter.jq is missing"
+  exit 1
+fi
+
+if ! command -v jq > /dev/null; then
+  printf "%s\n\n" "Is jq installed?"
+  exit 1
+fi
+
+if ! command -v curl > /dev/null; then
+  printf "%s\n\n" "Is curl installed?"
+  exit 1
+fi
+
+tokens_file=voorbeeld.tokens.json
+temp_dir=$(mktemp -d)
+trap 'rm -rf "${temp_dir}"' EXIT
+
+printf "%s\n\n" "Downloading latest tokens from the ‘themes’ repository."
+curl --silent -O --output-dir "${temp_dir}" "https://raw.githubusercontent.com/nl-design-system/themes/refs/heads/main/packages/voorbeeld-design-tokens/figma/${tokens_file}"
+
+printf "%s\n\n" "Extracting and converting ‘${1}’ tokens."
+jq -f "${script_path}/filter.jq" --arg key "components/${1}/nl" "${temp_dir}/${tokens_file}" | jq -S . > "./tokens.json"
+
+printf "%s\n\n" "Adding design tokens using this script will extend the official public API for design tokens. Changing design tokens might be a breaking change. Follow the official process for API changes and request reviews by the appropriate team members before you merge changes like this."


### PR DESCRIPTION
@Robbert script toegevoegd voor het genereren van token definities. Het script is voorbereid op de change van Jeffrey om naar `"components/<component>/nl"` te switchen en is niet meer afhankelijk van `themes` en `candidate` naast elkaar uitgecheckt hebben.

@jeffreylauwers dit heb ik 21-03 gedraaid, dus dit is de laatste versie die qua tokens overeenkomt met wat in `themes` zit. Tokens zijn alfabetisch gesorteerd wat betekent dat geneste states zoals `disabled` of `focus-visible` helaas niet zoals jij graag zou willen helemaal onderaan staan. Voordeel is wel dat dit altijd consistent is waar je denk ik ergens ook wel gelukkig van wordt.

## Todo

- [ ] Changeset