### PR TITLE
feat(skip-link-tokens): add new longhand tokens

### DIFF
--- a/.changeset/kind-bees-rule.md
+++ b/.changeset/kind-bees-rule.md
@@ -1,0 +1,19 @@
+---
+'@nl-design-system-candidate/skip-link-tokens': minor
+---
+
+New tokens:
+
+The following tokens have been added. They will replace the deprecated shorthand versions of these tokens.
+
+- `nl.skip-link.padding-block-start`
+- `nl.skip-link.padding-block-end`
+- `nl.skip-link.padding-inline-start`
+- `nl-skip-link.padding-inline-end`
+
+Deprecated tokens:
+
+The shorthand versions of the new tokens have been deprecated and should no longer be used.
+
+- `nl.skip-link.padding-block`
+- `nl.skip-link-padding-inline`

--- a/packages/tokens/skip-link-tokens/tokens.json
+++ b/packages/tokens/skip-link-tokens/tokens.json
@@ -46,11 +46,41 @@
       "padding-block": {
         "$extensions": {
           "nl.nldesignsystem.css-property-syntax": "<length>",
+          "nl.nldesignsystem.figma-implementation": true,
+          "nl.nldesignsystem.deprecated": true
+        },
+        "$type": "dimension"
+      },
+      "padding-block-end": {
+        "$extensions": {
+          "nl.nldesignsystem.css-property-syntax": "<length>",
+          "nl.nldesignsystem.figma-implementation": true
+        },
+        "$type": "dimension"
+      },
+      "padding-block-start": {
+        "$extensions": {
+          "nl.nldesignsystem.css-property-syntax": "<length>",
           "nl.nldesignsystem.figma-implementation": true
         },
         "$type": "dimension"
       },
       "padding-inline": {
+        "$extensions": {
+          "nl.nldesignsystem.css-property-syntax": "<length>",
+          "nl.nldesignsystem.figma-implementation": true,
+          "nl.nldesignsystem.deprecated": true
+        },
+        "$type": "dimension"
+      },
+      "padding-inline-end": {
+        "$extensions": {
+          "nl.nldesignsystem.css-property-syntax": "<length>",
+          "nl.nldesignsystem.figma-implementation": true
+        },
+        "$type": "dimension"
+      },
+      "padding-inline-start": {
         "$extensions": {
           "nl.nldesignsystem.css-property-syntax": "<length>",
           "nl.nldesignsystem.figma-implementation": true


### PR DESCRIPTION
- `nl.skip-link.padding-block-start/end`
- `nl.skip-link.padding-inline-start/end`

Deprecate:

- `nl.skip-link.padding-block`
- `nl.skip-link.padding-inline`