### PR TITLE
feat(skip-link-css): use new tokens

### DIFF
--- a/.changeset/hot-scissors-appear.md
+++ b/.changeset/hot-scissors-appear.md
@@ -1,0 +1,15 @@
+---
+'@nl-design-system-candidate/skip-link-css': minor
+---
+
+The following new tokens were added:
+
+- `nl.skip-link.padding-block-start`
+- `nl.skip-link.padding-block-end`
+- `nl.skip-link.padding-inline-start`
+- `nl-skip-link.padding-inline-end`
+
+The following shorthand versions of the new tokens have been deprecated and should no longer be used:
+
+- `nl.skip-link.padding-block`
+- `nl.skip-link.padding-inline`

--- a/packages/components-css/skip-link-css/src/_mixin.scss
+++ b/packages/components-css/skip-link-css/src/_mixin.scss
@@ -11,8 +11,10 @@
   max-inline-size: calc(100% - 2 * var(--_nl-skip-link-inset, 0));
   min-block-size: var(--nl-skip-link-min-block-size, 44px);
   min-inline-size: var(--nl-skip-link-min-inline-size, 44px);
-  padding-block: var(--nl-skip-link-padding-block);
-  padding-inline: var(--nl-skip-link-padding-inline);
+  padding-block-end: var(--nl-skip-link-padding-block-end, var(--nl-skip-link-padding-block));
+  padding-block-start: var(--nl-skip-link-padding-block-start, var(--nl-skip-link-padding-block));
+  padding-inline-end: var(--nl-skip-link-padding-inline-end, var(--nl-skip-link-padding-inline));
+  padding-inline-start: var(--nl-skip-link-padding-inline-start, var(--nl-skip-link-padding-inline));
   text-decoration-thickness: max(var(--nl-skip-link-text-decoration-thickness, 0px), initial);
   text-underline-offset: var(--nl-skip-link-text-underline-offset, initial);
 }
@@ -26,7 +28,7 @@
   /**
    * WCAG 2.2 / 2.4.12: "No part of the focus indicator is hidden by author-created content".
    * To go the extra mile, ensure the focus indicator is inside the viewport.
-   * 
+   *
    * Assume 2px is the browser default focus ring size.
    *
    * TODO: calc(


### PR DESCRIPTION
Use the new `nl.skip-link.padding-block-start/end` and `nl.skip-link.padding-inline-start/end` tokens.

Remove trailing whitespace from comment (prettier).