### PR TITLE
feat(paragraph-tokens): add new tokens

### DIFF
--- a/.changeset/lazy-worms-travel.md
+++ b/.changeset/lazy-worms-travel.md
@@ -1,0 +1,10 @@
+---
+'@nl-design-system-candidate/paragraph-tokens': minor
+---
+
+The following tokens were added in this release:
+
+- `nl.paragraph.margin-block-start`
+- `nl.paragraph.margin-block-end`
+- `nl.paragraph.lead.margin-block-start`
+- `nl.paragraph.lead.margin-block-end`

--- a/packages/tokens/paragraph-tokens/tokens.json
+++ b/packages/tokens/paragraph-tokens/tokens.json
@@ -50,6 +50,20 @@
             "nl.nldesignsystem.figma-implementation": true
           },
           "$type": "lineHeights"
+        },
+        "margin-block-end": {
+          "$extensions": {
+            "nl.nldesignsystem.css-property-syntax": "<length>",
+            "nl.nldesignsystem.figma-implementation": false
+          },
+          "$type": "dimension"
+        },
+        "margin-block-start": {
+          "$extensions": {
+            "nl.nldesignsystem.css-property-syntax": "<length>",
+            "nl.nldesignsystem.figma-implementation": false
+          },
+          "$type": "dimension"
         }
       },
       "line-height": {
@@ -58,6 +72,20 @@
           "nl.nldesignsystem.figma-implementation": true
         },
         "$type": "lineHeights"
+      },
+      "margin-block-end": {
+        "$extensions": {
+          "nl.nldesignsystem.css-property-syntax": "<length>",
+          "nl.nldesignsystem.figma-implementation": false
+        },
+        "$type": "dimension"
+      },
+      "margin-block-start": {
+        "$extensions": {
+          "nl.nldesignsystem.css-property-syntax": "<length>",
+          "nl.nldesignsystem.figma-implementation": false
+        },
+        "$type": "dimension"
       }
     }
   }


### PR DESCRIPTION
The following tokens were added:

- `nl.paragraph.margin-block-start`
- `nl.paragraph.margin-block-end`
- `nl.paragraph.lead.margin-block-start`
- `nl.paragraph.lead.margin-block-end`