### PR TITLE
chore: make Sass output compressed CSS

### DIFF
--- a/.changeset/blue-ghosts-warn.md
+++ b/.changeset/blue-ghosts-warn.md
@@ -1,0 +1,14 @@
+---
+'@nl-design-system-candidate/color-sample-css': patch
+'@nl-design-system-candidate/number-badge-css': patch
+'@nl-design-system-candidate/code-block-css': patch
+'@nl-design-system-candidate/data-badge-css': patch
+'@nl-design-system-candidate/paragraph-css': patch
+'@nl-design-system-candidate/skip-link-css': patch
+'@nl-design-system-candidate/heading-css': patch
+'@nl-design-system-candidate/code-css': patch
+'@nl-design-system-candidate/link-css': patch
+'@nl-design-system-candidate/mark-css': patch
+---
+
+Update Sass build script to output compressed CSS

--- a/packages/components-css/code-block-css/package.json
+++ b/packages/components-css/code-block-css/package.json
@@ -22,7 +22,7 @@
     "provenance": true
   },
   "scripts": {
-    "build": "sass ./src/:./dist/",
+    "build": "sass --style=compressed ./src/:./dist/",
     "clean": "rimraf ./dist/"
   }
 }

--- a/packages/components-css/code-css/package.json
+++ b/packages/components-css/code-css/package.json
@@ -22,7 +22,7 @@
     "provenance": true
   },
   "scripts": {
-    "build": "sass ./src/:./dist/",
+    "build": "sass --style=compressed ./src/:./dist/",
     "clean": "rimraf ./dist/"
   }
 }

--- a/packages/components-css/color-sample-css/package.json
+++ b/packages/components-css/color-sample-css/package.json
@@ -22,7 +22,7 @@
     "provenance": true
   },
   "scripts": {
-    "build": "sass ./src/:./dist/",
+    "build": "sass --style=compressed ./src/:./dist/",
     "clean": "rimraf ./dist/"
   }
 }

--- a/packages/components-css/data-badge-css/package.json
+++ b/packages/components-css/data-badge-css/package.json
@@ -22,7 +22,7 @@
     "provenance": true
   },
   "scripts": {
-    "build": "sass ./src/:./dist/",
+    "build": "sass --style=compressed ./src/:./dist/",
     "clean": "rimraf ./dist/"
   }
 }

--- a/packages/components-css/heading-css/package.json
+++ b/packages/components-css/heading-css/package.json
@@ -22,7 +22,7 @@
     "provenance": true
   },
   "scripts": {
-    "build": "sass ./src/:./dist/",
+    "build": "sass --style=compressed ./src/:./dist/",
     "clean": "rimraf ./dist/"
   }
 }

--- a/packages/components-css/link-css/package.json
+++ b/packages/components-css/link-css/package.json
@@ -22,7 +22,7 @@
     "provenance": true
   },
   "scripts": {
-    "build": "sass ./src/:./dist/",
+    "build": "sass --style=compressed ./src/:./dist/",
     "clean": "rimraf ./dist/"
   }
 }

--- a/packages/components-css/mark-css/package.json
+++ b/packages/components-css/mark-css/package.json
@@ -22,7 +22,7 @@
     "provenance": true
   },
   "scripts": {
-    "build": "sass ./src/:./dist/",
+    "build": "sass --style=compressed ./src/:./dist/",
     "clean": "rimraf ./dist/"
   }
 }

--- a/packages/components-css/number-badge-css/package.json
+++ b/packages/components-css/number-badge-css/package.json
@@ -22,7 +22,7 @@
     "provenance": true
   },
   "scripts": {
-    "build": "sass ./src/:./dist/",
+    "build": "sass --style=compressed ./src/:./dist/",
     "clean": "rimraf ./dist/"
   }
 }

--- a/packages/components-css/paragraph-css/package.json
+++ b/packages/components-css/paragraph-css/package.json
@@ -22,7 +22,7 @@
     "provenance": true
   },
   "scripts": {
-    "build": "sass ./src/:./dist/",
+    "build": "sass --style=compressed ./src/:./dist/",
     "clean": "rimraf ./dist/"
   }
 }

--- a/packages/components-css/skip-link-css/package.json
+++ b/packages/components-css/skip-link-css/package.json
@@ -22,7 +22,7 @@
     "provenance": true
   },
   "scripts": {
-    "build": "sass ./src/:./dist/",
+    "build": "sass --style=compressed ./src/:./dist/",
     "clean": "rimraf ./dist/"
   }
 }


### PR DESCRIPTION
This gets rid of comments in .css files