### PR TITLE
ci: dont require changeset for minor or patch updates from dependabot

### DIFF
--- a/.github/workflows/changeset-status.yml
+++ b/.github/workflows/changeset-status.yml
@@ -25,9 +25,21 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Changset status
+      - name: Fetch Dependabot metadata
+        id: dependabot-metadata
+        uses: dependabot/fetch-metadata@v2
+        if: ${{ github.actor == 'dependabot[bot]' }}
+
+      - name: Changeset status
         id: changeset-status
         run: |
+          if [[ "${{ github.actor }}" == "dependabot[bot]" ]]; then
+            if [[ "${{ steps.dependabot-metadata.outputs.update-type }}" == "version-update:semver-patch" ]] || [[ "${{ steps.dependabot-metadata.outputs.update-type }}" == "version-update:semver-minor" ]]; then
+              echo "status=0" | tee -a $GITHUB_OUTPUT
+              exit 0
+            fi
+          fi
+
           if pnpm run changeset:status; then
             echo "status=0" | tee -a $GITHUB_OUTPUT
           else


### PR DESCRIPTION
Using dependabot/fetch-metadata with the output `steps.dependabot-metadata.outputs.update-type` to return the highest semver change being made by the PR