### PR TITLE
refactor(link-tokens): remove tokens

### DIFF
--- a/.changeset/tender-readers-search.md
+++ b/.changeset/tender-readers-search.md
@@ -1,0 +1,17 @@
+---
+'@nl-design-system-candidate/link-tokens': major
+---
+
+This release contains **breaking** changes.
+
+The following tokens were never used in the community and have been removed:
+
+- `nl.link.active.text-decoration-line`
+- `nl.link.active.text-decoration-thickness`
+
+We are working towards common design tokens that take care of the focus state instead of handling this at the component level. Therefore the following focus related tokens have been removed:
+
+- `nl.link.focus-visible.background-color`
+- `nl.link.focus-visible.color`
+- `nl.link.focus-visible.text-decoration-line`
+- `nl.link.focus-visible.text-decoration-thickness`

--- a/packages/tokens/link-tokens/tokens.json
+++ b/packages/tokens/link-tokens/tokens.json
@@ -8,20 +8,6 @@
             "nl.nldesignsystem.figma-implementation": true
           },
           "$type": "color"
-        },
-        "text-decoration-line": {
-          "$extensions": {
-            "nl.nldesignsystem.css-property-syntax": ["inherit", "none", "underline"],
-            "nl.nldesignsystem.figma-implementation": true
-          },
-          "$type": "textDecoration"
-        },
-        "text-decoration-thickness": {
-          "$extensions": {
-            "nl.nldesignsystem.css-property-syntax": "<length>",
-            "nl.nldesignsystem.figma-implementation": false
-          },
-          "$type": "other"
         }
       },
       "color": {
@@ -51,36 +37,6 @@
         "cursor": {
           "$extensions": {
             "nl.nldesignsystem.css-property-syntax": ["<url>", "pointer", "*"],
-            "nl.nldesignsystem.figma-implementation": false
-          },
-          "$type": "other"
-        }
-      },
-      "focus-visible": {
-        "background-color": {
-          "$extensions": {
-            "nl.nldesignsystem.css-property-syntax": "<color>",
-            "nl.nldesignsystem.figma-implementation": true
-          },
-          "$type": "color"
-        },
-        "color": {
-          "$extensions": {
-            "nl.nldesignsystem.css-property-syntax": "<color>",
-            "nl.nldesignsystem.figma-implementation": true
-          },
-          "$type": "color"
-        },
-        "text-decoration-line": {
-          "$extensions": {
-            "nl.nldesignsystem.css-property-syntax": ["inherit", "none", "underline"],
-            "nl.nldesignsystem.figma-implementation": true
-          },
-          "$type": "textDecoration"
-        },
-        "text-decoration-thickness": {
-          "$extensions": {
-            "nl.nldesignsystem.css-property-syntax": "<length>",
             "nl.nldesignsystem.figma-implementation": false
           },
           "$type": "other"


### PR DESCRIPTION
The following tokens were removed:

- `nl.link.active.text-decoration-line`
- `nl.link.active.text-decoration-thickness`
- `nl.link.focus-visible.background-color`
- `nl.link.focus-visible.color`
- `nl.link.focus-visible.text-decoration-line`
- `nl.link.focus-visible.text-decoration-thickness`