### PR TITLE
docs: CONTRIBUTING toevoegen (#548)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -10,6 +10,7 @@ body:
 
         Vul het onderstaande formulier in om een GitHub issue aan te maken.
 
+        Wil je je issue ondersteunen met codewijzigingen? Dit doe je vanuit een fork van de repository. Zie [CONTRIBUTING.md](https://github.com/nl-design-system/candidate/blob/main/CONTRIBUTING.md) voor de juiste werkwijze.
   - type: dropdown
     id: component
     attributes:

--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -10,7 +10,7 @@ body:
 
         Vul het onderstaande formulier in om een GitHub issue aan te maken.
 
-        Wil je je issue ondersteunen met codewijzigingen? Dit doe je vanuit een fork van de repository. Zie [CONTRIBUTING.md](https://github.com/nl-design-system/candidate/blob/main/CONTRIBUTING.md) voor de juiste werkwijze.
+        Wil je je issue ondersteunen met codewijzigingen? Dit doe je vanuit een fork van de repository. Zie [CONTRIBUTING.md](./CONTRIBUTING.md) voor de juiste werkwijze.
   - type: dropdown
     id: component
     attributes:

--- a/.github/ISSUE_TEMPLATE/docs.yml
+++ b/.github/ISSUE_TEMPLATE/docs.yml
@@ -9,10 +9,9 @@ body:
       value: |
         Allereerst bedankt voor je bijdrage!
 
-        Voor documenatie updates mogen pull requests naar de `main` branch gemaakt worden.
+        Wil je iets aanpassen in de documentatie? Je kunt hiervoor een pull request maken naar de `main` branch. Dit doe je vanuit een fork van de repository. Zie [CONTRIBUTING.md](https://github.com/nl-design-system/candidate/blob/main/CONTRIBUTING.md) voor de juiste werkwijze.
 
         Als je geen pull request maakt kun je in dit issue aangeven wat er niet correct is of wat je mist in de documentatie.
-
   - type: textarea
     attributes:
       label: Beschrijf wat er niet correct is of ontbreekt in de documentatie

--- a/.github/ISSUE_TEMPLATE/docs.yml
+++ b/.github/ISSUE_TEMPLATE/docs.yml
@@ -9,7 +9,7 @@ body:
       value: |
         Allereerst bedankt voor je bijdrage!
 
-        Wil je iets aanpassen in de documentatie? Je kunt hiervoor een pull request maken naar de `main` branch. Dit doe je vanuit een fork van de repository. Zie [CONTRIBUTING.md](https://github.com/nl-design-system/candidate/blob/main/CONTRIBUTING.md) voor de juiste werkwijze.
+        Wil je iets aanpassen in de documentatie? Je kunt hiervoor een pull request maken naar de `main` branch. Dit doe je vanuit een fork van de repository. Zie [CONTRIBUTING.md](./CONTRIBUTING.md) voor de juiste werkwijze.
 
         Als je geen pull request maakt kun je in dit issue aangeven wat er niet correct is of wat je mist in de documentatie.
   - type: textarea

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,36 @@
+# Bijdragen aan dit project
+
+Allereerst bedankt voor je bijdrage! Lees onderstaande richtlijnen om het bijdragen zo soepel mogelijk te laten verlopen.
+
+## Voorbereiden
+
+- Bekijk de [README.md](./README.md) voor informatie over hoe je het project opzet en gebruikt.
+- Lees ook de bestaande issues en pull requests om te voorkomen dat je werk dubbel wordt gedaan.
+
+## Bijdragen
+
+Er zijn twee manieren om bij te dragen:
+
+### 1. Een issue aanmaken
+
+- Maak een issue aan via GitHub.
+- Gebruik de juiste issue template om je vraag of probleem zo volledig mogelijk te omschrijven.
+
+### 2. Een branch of pull request maken
+
+Omdat je **geen rechten hebt om direct naar deze repository te pushen**, volg je deze stappen:
+
+1. **Fork** deze repository naar je eigen GitHub account.
+2. Maak een nieuwe branch voor je wijzigingen en commit je wijzigingen in je eigen fork.
+3. Push je branch naar je eigen fork op GitHub.
+4. Maak vanuit je fork een **pull request** naar de `main` branch van deze repository.
+
+**Tips**:
+- Voeg een duidelijke titel en beschrijving toe aan je PR.
+- Kleine, overzichtelijke PR's zijn makkelijker te beoordelen en sneller te mergen.
+
+## Vragen?
+
+Maak een issue aan, neem contact op met het [kernteam](https://nldesignsystem.nl/project/kernteam/) of stel je vraag in het [#nl-design-system Slack kanaal](https://praatmee.codefor.nl) op CodeForNL.
+
+Bedankt voor je bijdrage!

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,6 +26,7 @@ Omdat je **geen rechten hebt om direct naar deze repository te pushen**, volg je
 4. Maak vanuit je fork een **pull request** naar de `main` branch van deze repository.
 
 **Tips**:
+
 - Voeg een duidelijke titel en beschrijving toe aan je PR.
 - Kleine, overzichtelijke PR's zijn makkelijker te beoordelen en sneller te mergen.
 


### PR DESCRIPTION
- Voegt CONTRIBUTING.md toe.
- Refereert naar CONTRIBUTING.md in issue templates, om duidelijk te maken dat men eerst de repository moet forken om code te kunnen bijdragen.

Closes #548