### PR TITLE
ci: change Chromatic configuration

### DIFF
--- a/.github/workflows/visual-regression-test.yml
+++ b/.github/workflows/visual-regression-test.yml
@@ -48,6 +48,6 @@ jobs:
         uses: chromaui/action@58d9ffb36c90c97a02d061544ecc849cc4a242a9 # v13.1.3
         with:
           autoAcceptChanges: main
-          onlyChanged: true
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
           storybookBuildDir: packages/storybook-test/dist/
+          exitOnceUploaded: true


### PR DESCRIPTION
Disable TurboSnap because that seems to require a Webpack thing but we use Vite instead of Webpack.

Add `exitOnceUploaded` because that is recommended during the ci run.