### PR TITLE
ci: update Dependabot ignores

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,8 +15,28 @@ updates:
         update-types:
           - "patch"
           - "minor"
+    # Keep ignores in line with their respective npm-check-updates configs:
+    # - "version-update:semver-patch" -> .ncurc.patch.cjs
+    # - "version-update:semver-minor" -> .ncurc.minor.cjs
+    # - "version-update:semver-major" -> .ncurc.major.cjs
     ignore:
       - dependency-name: "@types/node"
+        update-types:
+          - "version-update:semver-major"
+      # the following 5 ignored dependencies should be removed when we update to Storybook 9
+      - dependency-name: "@storybook/*"
+        update-types:
+          - "version-update:semver-major"
+      - dependency-name: "storybook"
+        update-types:
+          - "version-update:semver-major"
+      - dependency-name: "@etchteam/storybook-addon-status"
+        update-types:
+          - "version-update:semver-major"
+      - dependency-name: "@whitespace/storybook-addon-html"
+        update-types:
+          - "version-update:semver-major"
+      - dependency-name: "vite"
         update-types:
           - "version-update:semver-major"
     versioning-strategy: "increase-if-necessary"

--- a/.ncurc.major.cjs
+++ b/.ncurc.major.cjs
@@ -2,6 +2,7 @@ const minorConfig = require('./.ncurc.minor.cjs');
 
 module.exports = {
   ...minorConfig,
+  // Keep the contents of `reject` in line with "version-update:semver-major" ignore entries in .github/dependabot.yml
   reject: [
     ...minorConfig.reject,
     // @types/node is kept in line with the node version in .nvmrc and package.json#engines.node
@@ -14,6 +15,7 @@ module.exports = {
     '@storybook/*',
     'storybook',
     '@etchteam/storybook-addon-status', // v5 is the last version that's compatible with Storybook 8
+    '@whitespace/storybook-addon-html', // we are waiting for this version bump to upgrade to Storybook 9
     'vite', // keep vite at v6 to stay in line with @storybook/react-vite
   ],
   target: 'latest',

--- a/.ncurc.minor.cjs
+++ b/.ncurc.minor.cjs
@@ -2,6 +2,7 @@ const patchConfig = require('./.ncurc.patch.cjs');
 
 module.exports = {
   ...patchConfig,
+  // Keep the contents of `reject` in line with "version-update:semver-minor" ignore entries in .github/dependabot.yml
   reject: [...patchConfig.reject],
   target: 'minor',
 };

--- a/.ncurc.patch.cjs
+++ b/.ncurc.patch.cjs
@@ -1,6 +1,7 @@
 module.exports = {
   dep: ['dev', 'prod'],
   install: 'always',
+  // Keep the contents of `reject` in line with "version-update:semver-patch" ignore entries in .github/dependabot.yml
   reject: [],
   root: true,
   target: 'patch',


### PR DESCRIPTION
Prevent Dependabot from updating Storybook to Storybook 9 as well as the 2 third party addons we use.

We cannot update yet because `@whitespace/storybook-addon-html` is not yet compatible with Storybook 9.