### PR TITLE
chore: prettierignore

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -16,6 +16,7 @@ CHANGELOG.md
 package-lock.json
 yarn.lock
 pnpm-lock.yaml
+pnpm-workspace.yaml
 
 
 # Ignore generated files from Stencil

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,12 +1,17 @@
-autoInstallPeers: false
-engineStrict: true
-onlyBuiltDependencies:
-  - esbuild
-saveExact: true
-savePrefix: ""
 packages:
   - packages/*
   - packages/components-react/*
   - packages/components-css/*
   - packages/docs/*
   - packages/tokens/*
+
+autoInstallPeers: false
+
+engineStrict: true
+
+onlyBuiltDependencies:
+  - esbuild
+
+saveExact: true
+
+savePrefix: ''


### PR DESCRIPTION
Make sure that Prettier ignores pnpm-workspace.yaml because pnpm itself is responsible for formatting it.