### PR TITLE
refactor: code-react

### DIFF
--- a/.changeset/forty-nights-sit.md
+++ b/.changeset/forty-nights-sit.md
@@ -1,0 +1,7 @@
+---
+'@nl-design-system-candidate/code-react': patch
+---
+
+Add missing devDependencies so the project can be built on its own.
+
+Remove the clsx dependency and replace it with a oneliner equivalent to concatenate classNames.

--- a/packages/components-react/code-react/package.json
+++ b/packages/components-react/code-react/package.json
@@ -37,16 +37,21 @@
     "typecheck": "tsc"
   },
   "devDependencies": {
+    "@babel/preset-env": "7.28.0",
+    "@babel/preset-react": "7.27.1",
+    "@babel/preset-typescript": "7.27.1",
     "@babel/runtime": "7.28.2",
     "@nl-design-system-candidate/code-css": "workspace:*",
+    "@nl-design-system/rollup-config-react-component": "1.0.6",
     "@types/react": "18.3.23",
-    "react": "18.3.1"
+    "react": "18.3.1",
+    "rimraf": "6.0.1",
+    "rollup": "4.46.2",
+    "typescript": "5.9.2",
+    "vitest": "3.2.4"
   },
   "peerDependencies": {
     "@babel/runtime": "^7",
     "react": "^18"
-  },
-  "dependencies": {
-    "clsx": "2.1.1"
   }
 }

--- a/packages/components-react/code-react/src/code.tsx
+++ b/packages/components-react/code-react/src/code.tsx
@@ -1,14 +1,15 @@
 import type { HTMLAttributes } from 'react';
-import { clsx } from 'clsx';
 import { forwardRef } from 'react';
 
 export type CodeProps = HTMLAttributes<HTMLElement>;
+
+const cn = (...classes: Array<string | undefined | null>): string => classes.filter(Boolean).join(' ');
 
 export const Code = forwardRef<HTMLElement, CodeProps>(function Code(props, forwardedRef) {
   const { children, className, ...restProps } = props;
 
   return (
-    <code dir="ltr" translate="no" className={clsx('nl-code', className)} {...restProps} ref={forwardedRef}>
+    <code dir="ltr" translate="no" className={cn('nl-code', className)} {...restProps} ref={forwardedRef}>
       {children}
     </code>
   );

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -161,23 +161,43 @@ importers:
         version: 18.3.1
 
   packages/components-react/code-react:
-    dependencies:
-      clsx:
-        specifier: 2.1.1
-        version: 2.1.1
     devDependencies:
+      '@babel/preset-env':
+        specifier: 7.28.0
+        version: 7.28.0(@babel/core@7.28.0)
+      '@babel/preset-react':
+        specifier: 7.27.1
+        version: 7.27.1(@babel/core@7.28.0)
+      '@babel/preset-typescript':
+        specifier: 7.27.1
+        version: 7.27.1(@babel/core@7.28.0)
       '@babel/runtime':
         specifier: 7.28.2
         version: 7.28.2
       '@nl-design-system-candidate/code-css':
         specifier: workspace:*
         version: link:../../components-css/code-css
+      '@nl-design-system/rollup-config-react-component':
+        specifier: 1.0.6
+        version: 1.0.6(@types/babel__core@7.20.5)(postcss@8.5.6)(rollup@4.46.2)(tslib@2.6.3)(typescript@5.9.2)
       '@types/react':
         specifier: 18.3.23
         version: 18.3.23
       react:
         specifier: 18.3.1
         version: 18.3.1
+      rimraf:
+        specifier: 6.0.1
+        version: 6.0.1
+      rollup:
+        specifier: 4.46.2
+        version: 4.46.2
+      typescript:
+        specifier: 5.9.2
+        version: 5.9.2
+      vitest:
+        specifier: 3.2.4
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@22.17.0)(jsdom@26.1.0)(sass@1.89.2)(yaml@2.8.0)
 
   packages/components-react/color-sample-react:
     dependencies:


### PR DESCRIPTION
Add missing devDependencies so @nl-design-system-candidate/code can be built on its own.

Replace clsx with a oneliner equivalent.