### PR TITLE
refactor: data-badge-react

### DIFF
--- a/.changeset/wise-cougars-stay.md
+++ b/.changeset/wise-cougars-stay.md
@@ -1,0 +1,10 @@
+---
+'@nl-design-system-candidate/data-badge-react': patch
+---
+
+Add missing devDependencies so the package can be built on its own.
+
+Replace clsx with a oneliner equivalent.
+
+Internally simplify DataBadgeProps and fix an error where the value attribute for `<data>` came from
+`DataHTMLAttributes<HTMLTimeElement>['value']` instead of `DataHTMLAttributes<HTMLDataElement>['value']`.

--- a/packages/components-react/data-badge-react/package.json
+++ b/packages/components-react/data-badge-react/package.json
@@ -37,16 +37,21 @@
     "typecheck": "tsc"
   },
   "devDependencies": {
+    "@babel/preset-env": "7.28.0",
+    "@babel/preset-react": "7.27.1",
+    "@babel/preset-typescript": "7.27.1",
     "@babel/runtime": "7.28.2",
     "@nl-design-system-candidate/data-badge-css": "workspace:*",
+    "@nl-design-system/rollup-config-react-component": "1.0.6",
     "@types/react": "18.3.23",
-    "react": "18.3.1"
+    "react": "18.3.1",
+    "rimraf": "6.0.1",
+    "rollup": "4.46.2",
+    "typescript": "5.9.2",
+    "vitest": "3.2.4"
   },
   "peerDependencies": {
     "@babel/runtime": "^7",
     "react": "^18"
-  },
-  "dependencies": {
-    "clsx": "2.1.1"
   }
 }

--- a/packages/components-react/data-badge-react/src/data-badge.tsx
+++ b/packages/components-react/data-badge-react/src/data-badge.tsx
@@ -1,30 +1,36 @@
 import type { DataHTMLAttributes, ForwardedRef, HTMLAttributes, TimeHTMLAttributes } from 'react';
 import { forwardRef } from 'react';
 
-interface DataBadgePropsForTime extends TimeHTMLAttributes<HTMLTimeElement> {
-  dateTime: TimeHTMLAttributes<HTMLTimeElement>['dateTime'];
-  value?: never;
+export type DataBadgeProps =
+  // <time> variant
+  | (Omit<TimeHTMLAttributes<HTMLTimeElement>, 'value'> & {
+      dateTime: TimeHTMLAttributes<HTMLTimeElement>['dateTime'];
+      value?: never;
+    })
+  // <data> variant
+  | (Omit<DataHTMLAttributes<HTMLDataElement>, 'dateTime'> & {
+      dateTime?: never;
+      value: DataHTMLAttributes<HTMLDataElement>['value'];
+    })
+  // <span> variant
+  | Omit<HTMLAttributes<HTMLSpanElement>, 'datetime' | 'value'>;
+
+export function isTimeDataBadgeProps(props: DataBadgeProps): props is Extract<DataBadgeProps, { dateTime: unknown }> {
+  return 'dateTime' in props;
 }
 
-const isDataBadgePropsForTime = (props: DataBadgeProps): props is DataBadgePropsForTime => 'dateTime' in props;
-
-interface DataBadgePropsForData extends DataHTMLAttributes<HTMLDataElement> {
-  dateTime?: never;
-  value: DataHTMLAttributes<HTMLTimeElement>['value'];
+export function isDataDataBadgeProps(props: DataBadgeProps): props is Extract<DataBadgeProps, { value: unknown }> {
+  return 'value' in props;
 }
-
-const isDataBadgePropsForData = (props: DataBadgeProps): props is DataBadgePropsForData => 'value' in props;
 
 const cn = (...classes: Array<string | undefined | null>): string => classes.filter(Boolean).join(' ');
-
-export type DataBadgeProps = DataBadgePropsForTime | DataBadgePropsForData | HTMLAttributes<HTMLSpanElement>;
 
 export const DataBadge = forwardRef<HTMLTimeElement | HTMLDataElement | HTMLSpanElement, DataBadgeProps>(
   function DataBadge(props, ref) {
     const { children, ...restProps } = props;
     const className = cn('nl-data-badge', props.className);
 
-    if (isDataBadgePropsForTime(restProps)) {
+    if (isTimeDataBadgeProps(restProps)) {
       const { dateTime, ...timeRestProps } = restProps;
       return (
         <time {...timeRestProps} dateTime={dateTime} className={className} ref={ref as ForwardedRef<HTMLTimeElement>}>
@@ -33,7 +39,7 @@ export const DataBadge = forwardRef<HTMLTimeElement | HTMLDataElement | HTMLSpan
       );
     }
 
-    if (isDataBadgePropsForData(restProps)) {
+    if (isDataDataBadgeProps(restProps)) {
       const { value, ...dataRestProps } = restProps;
       return (
         <data {...dataRestProps} value={value} className={className} ref={ref as ForwardedRef<HTMLDataElement>}>

--- a/packages/components-react/data-badge-react/src/data-badge.tsx
+++ b/packages/components-react/data-badge-react/src/data-badge.tsx
@@ -1,5 +1,4 @@
 import type { DataHTMLAttributes, ForwardedRef, HTMLAttributes, TimeHTMLAttributes } from 'react';
-import { clsx } from 'clsx';
 import { forwardRef } from 'react';
 
 interface DataBadgePropsForTime extends TimeHTMLAttributes<HTMLTimeElement> {
@@ -16,12 +15,14 @@ interface DataBadgePropsForData extends DataHTMLAttributes<HTMLDataElement> {
 
 const isDataBadgePropsForData = (props: DataBadgeProps): props is DataBadgePropsForData => 'value' in props;
 
+const cn = (...classes: Array<string | undefined | null>): string => classes.filter(Boolean).join(' ');
+
 export type DataBadgeProps = DataBadgePropsForTime | DataBadgePropsForData | HTMLAttributes<HTMLSpanElement>;
 
 export const DataBadge = forwardRef<HTMLTimeElement | HTMLDataElement | HTMLSpanElement, DataBadgeProps>(
   function DataBadge(props, ref) {
     const { children, ...restProps } = props;
-    const className = clsx('nl-data-badge', props.className);
+    const className = cn('nl-data-badge', props.className);
 
     if (isDataBadgePropsForTime(restProps)) {
       const { dateTime, ...timeRestProps } = restProps;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -239,23 +239,43 @@ importers:
         version: 3.2.4(@types/debug@4.1.12)(@types/node@22.17.0)(jsdom@26.1.0)(sass@1.89.2)(yaml@2.8.0)
 
   packages/components-react/data-badge-react:
-    dependencies:
-      clsx:
-        specifier: 2.1.1
-        version: 2.1.1
     devDependencies:
+      '@babel/preset-env':
+        specifier: 7.28.0
+        version: 7.28.0(@babel/core@7.28.0)
+      '@babel/preset-react':
+        specifier: 7.27.1
+        version: 7.27.1(@babel/core@7.28.0)
+      '@babel/preset-typescript':
+        specifier: 7.27.1
+        version: 7.27.1(@babel/core@7.28.0)
       '@babel/runtime':
         specifier: 7.28.2
         version: 7.28.2
       '@nl-design-system-candidate/data-badge-css':
         specifier: workspace:*
         version: link:../../components-css/data-badge-css
+      '@nl-design-system/rollup-config-react-component':
+        specifier: 1.0.6
+        version: 1.0.6(@types/babel__core@7.20.5)(postcss@8.5.6)(rollup@4.46.2)(tslib@2.6.3)(typescript@5.9.2)
       '@types/react':
         specifier: 18.3.23
         version: 18.3.23
       react:
         specifier: 18.3.1
         version: 18.3.1
+      rimraf:
+        specifier: 6.0.1
+        version: 6.0.1
+      rollup:
+        specifier: 4.46.2
+        version: 4.46.2
+      typescript:
+        specifier: 5.9.2
+        version: 5.9.2
+      vitest:
+        specifier: 3.2.4
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@22.17.0)(jsdom@26.1.0)(sass@1.89.2)(yaml@2.8.0)
 
   packages/components-react/heading-react:
     dependencies:


### PR DESCRIPTION
Add missing devDependencies so @nl-design-system-candidate/data-badge-react can be built on its own.

Replace clsx with a oneliner equivalent.

Simplify DataBadgeProps by getting rid of the intermediary DataBadgePropsForTime and DataBadgePropsForData.

Fix the original props for <data> where the value attribute came from `DataHTMLAttributes<HTMLTimeElement>['value']` instead of `DataHTMLAttributes<HTMLDataElement>['value']`.