### PR TITLE
Refactor/mark clsx

### DIFF
--- a/.changeset/hungry-oranges-accept.md
+++ b/.changeset/hungry-oranges-accept.md
@@ -1,0 +1,5 @@
+---
+'@nl-design-system-candidate/mark-react': patch
+---
+
+Remove the clsx dependency and replace it with a oneliner equivalent to concatenate classNames.

--- a/.changeset/proud-apes-hang.md
+++ b/.changeset/proud-apes-hang.md
@@ -1,0 +1,5 @@
+---
+'@nl-design-system-candidate/mark-react': patch
+---
+
+Add missing devDependencies so the project can be built on its own.

--- a/packages/components-react/mark-react/package.json
+++ b/packages/components-react/mark-react/package.json
@@ -45,8 +45,5 @@
   "peerDependencies": {
     "@babel/runtime": "^7",
     "react": "^18"
-  },
-  "dependencies": {
-    "clsx": "2.1.1"
   }
 }

--- a/packages/components-react/mark-react/package.json
+++ b/packages/components-react/mark-react/package.json
@@ -37,10 +37,18 @@
     "typecheck": "tsc"
   },
   "devDependencies": {
+    "@babel/preset-env": "7.28.0",
+    "@babel/preset-react": "7.27.1",
+    "@babel/preset-typescript": "7.27.1",
     "@babel/runtime": "7.28.2",
     "@nl-design-system-candidate/mark-css": "workspace:*",
+    "@nl-design-system/rollup-config-react-component": "1.0.6",
     "@types/react": "18.3.23",
-    "react": "18.3.1"
+    "react": "18.3.1",
+    "rimraf": "6.0.1",
+    "rollup": "4.46.2",
+    "typescript": "5.9.2",
+    "vitest": "3.2.4"
   },
   "peerDependencies": {
     "@babel/runtime": "^7",

--- a/packages/components-react/mark-react/src/mark.tsx
+++ b/packages/components-react/mark-react/src/mark.tsx
@@ -1,6 +1,7 @@
 import type { HTMLAttributes } from 'react';
-import { clsx } from 'clsx';
 import { forwardRef } from 'react';
+
+const cn = (...classes: Array<string | undefined | null>): string => classes.filter(Boolean).join(' ');
 
 export type MarkProps = HTMLAttributes<HTMLElement>;
 
@@ -8,7 +9,7 @@ export const Mark = forwardRef<HTMLElement, MarkProps>(function Mark(props, forw
   const { children, className, ...restProps } = props;
 
   return (
-    <mark {...restProps} className={clsx('nl-mark', className)} ref={forwardedRef}>
+    <mark {...restProps} className={cn('nl-mark', className)} ref={forwardedRef}>
       {children}
     </mark>
   );

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -335,10 +335,6 @@ importers:
         version: 18.3.1
 
   packages/components-react/mark-react:
-    dependencies:
-      clsx:
-        specifier: 2.1.1
-        version: 2.1.1
     devDependencies:
       '@babel/runtime':
         specifier: 7.28.2

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -336,18 +336,42 @@ importers:
 
   packages/components-react/mark-react:
     devDependencies:
+      '@babel/preset-env':
+        specifier: 7.28.0
+        version: 7.28.0(@babel/core@7.28.0)
+      '@babel/preset-react':
+        specifier: 7.27.1
+        version: 7.27.1(@babel/core@7.28.0)
+      '@babel/preset-typescript':
+        specifier: 7.27.1
+        version: 7.27.1(@babel/core@7.28.0)
       '@babel/runtime':
         specifier: 7.28.2
         version: 7.28.2
       '@nl-design-system-candidate/mark-css':
         specifier: workspace:*
         version: link:../../components-css/mark-css
+      '@nl-design-system/rollup-config-react-component':
+        specifier: 1.0.6
+        version: 1.0.6(@types/babel__core@7.20.5)(postcss@8.5.6)(rollup@4.46.2)(tslib@2.6.3)(typescript@5.9.2)
       '@types/react':
         specifier: 18.3.23
         version: 18.3.23
       react:
         specifier: 18.3.1
         version: 18.3.1
+      rimraf:
+        specifier: 6.0.1
+        version: 6.0.1
+      rollup:
+        specifier: 4.46.2
+        version: 4.46.2
+      typescript:
+        specifier: 5.9.2
+        version: 5.9.2
+      vitest:
+        specifier: 3.2.4
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@22.17.0)(jsdom@26.1.0)(sass@1.89.2)(yaml@2.8.0)
 
   packages/components-react/number-badge-react:
     dependencies:


### PR DESCRIPTION
Remove the clsx dependency and replace it with a oneliner equivalent to concatenate classNames.

Add missing devDependencies so @nl-design-system-candidate/mark-react can be built on its own.