### PR TITLE
refactor: heading-react

### DIFF
--- a/.changeset/curvy-steaks-refuse.md
+++ b/.changeset/curvy-steaks-refuse.md
@@ -1,0 +1,5 @@
+---
+'@nl-design-system-candidate/heading-react': patch
+---
+
+Add missing devDependencies so the project can be built on its own.

--- a/.changeset/sharp-loops-roll.md
+++ b/.changeset/sharp-loops-roll.md
@@ -1,0 +1,5 @@
+---
+'@nl-design-system-candidate/heading-react': patch
+---
+
+Remove the clsx dependency and replace it with a oneliner equivalent to concatenate classNames.

--- a/packages/components-react/heading-react/package.json
+++ b/packages/components-react/heading-react/package.json
@@ -45,8 +45,5 @@
   "peerDependencies": {
     "@babel/runtime": "^7",
     "react": "^18"
-  },
-  "dependencies": {
-    "clsx": "2.1.1"
   }
 }

--- a/packages/components-react/heading-react/package.json
+++ b/packages/components-react/heading-react/package.json
@@ -37,10 +37,18 @@
     "typecheck": "tsc"
   },
   "devDependencies": {
+    "@babel/preset-env": "7.28.0",
+    "@babel/preset-react": "7.27.1",
+    "@babel/preset-typescript": "7.27.1",
     "@babel/runtime": "7.28.2",
     "@nl-design-system-candidate/heading-css": "workspace:*",
+    "@nl-design-system/rollup-config-react-component": "1.0.6",
     "@types/react": "18.3.23",
-    "react": "18.3.1"
+    "react": "18.3.1",
+    "rimraf": "6.0.1",
+    "rollup": "4.46.2",
+    "typescript": "5.9.2",
+    "vitest": "3.2.4"
   },
   "peerDependencies": {
     "@babel/runtime": "^7",

--- a/packages/components-react/heading-react/src/heading.ts
+++ b/packages/components-react/heading-react/src/heading.ts
@@ -1,5 +1,4 @@
 import type { HTMLAttributes } from 'react';
-import { clsx } from 'clsx';
 import { forwardRef, createElement } from 'react';
 
 export const headingLevels = [1, 2, 3, 4, 5, 6] as const;
@@ -13,13 +12,15 @@ export interface HeadingProps extends HTMLAttributes<HTMLHeadingElement> {
   appearance?: HeadingAppearance;
 }
 
+const cn = (...classes: Array<string | undefined | null>): string => classes.filter(Boolean).join(' ');
+
 export const Heading = forwardRef<HTMLHeadingElement, HeadingProps>(function Heading(props, forwardedRef) {
   const { level, appearance = `level-${level}`, children, className, ...restProps } = props;
   const type = `h${level}` as keyof JSX.IntrinsicElements;
 
   return createElement(
     type,
-    { className: clsx('nl-heading', `nl-heading--${appearance}`, className), ref: forwardedRef, ...restProps },
+    { className: cn('nl-heading', `nl-heading--${appearance}`, className), ref: forwardedRef, ...restProps },
     children,
   );
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -278,10 +278,6 @@ importers:
         version: 3.2.4(@types/debug@4.1.12)(@types/node@22.17.0)(jsdom@26.1.0)(sass@1.89.2)(yaml@2.8.0)
 
   packages/components-react/heading-react:
-    dependencies:
-      clsx:
-        specifier: 2.1.1
-        version: 2.1.1
     devDependencies:
       '@babel/runtime':
         specifier: 7.28.2

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -279,18 +279,42 @@ importers:
 
   packages/components-react/heading-react:
     devDependencies:
+      '@babel/preset-env':
+        specifier: 7.28.0
+        version: 7.28.0(@babel/core@7.28.0)
+      '@babel/preset-react':
+        specifier: 7.27.1
+        version: 7.27.1(@babel/core@7.28.0)
+      '@babel/preset-typescript':
+        specifier: 7.27.1
+        version: 7.27.1(@babel/core@7.28.0)
       '@babel/runtime':
         specifier: 7.28.2
         version: 7.28.2
       '@nl-design-system-candidate/heading-css':
         specifier: workspace:*
         version: link:../../components-css/heading-css
+      '@nl-design-system/rollup-config-react-component':
+        specifier: 1.0.6
+        version: 1.0.6(@types/babel__core@7.20.5)(postcss@8.5.6)(rollup@4.46.2)(tslib@2.6.3)(typescript@5.9.2)
       '@types/react':
         specifier: 18.3.23
         version: 18.3.23
       react:
         specifier: 18.3.1
         version: 18.3.1
+      rimraf:
+        specifier: 6.0.1
+        version: 6.0.1
+      rollup:
+        specifier: 4.46.2
+        version: 4.46.2
+      typescript:
+        specifier: 5.9.2
+        version: 5.9.2
+      vitest:
+        specifier: 3.2.4
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@22.17.0)(jsdom@26.1.0)(sass@1.89.2)(yaml@2.8.0)
 
   packages/components-react/icon-react:
     dependencies:


### PR DESCRIPTION
Remove the clsx dependency and replace it with a oneliner equivalent to concatenate classNames.

Add missing devDependencies so @nl-design-system-candidate/heading-react can be built on its own.