### PR TITLE
refactor: add missing devDependencies to *-css

### DIFF
--- a/.changeset/neat-shrimps-listen.md
+++ b/.changeset/neat-shrimps-listen.md
@@ -1,0 +1,14 @@
+---
+'@nl-design-system-candidate/color-sample-css': patch
+'@nl-design-system-candidate/number-badge-css': patch
+'@nl-design-system-candidate/code-block-css': patch
+'@nl-design-system-candidate/data-badge-css': patch
+'@nl-design-system-candidate/paragraph-css': patch
+'@nl-design-system-candidate/skip-link-css': patch
+'@nl-design-system-candidate/heading-css': patch
+'@nl-design-system-candidate/code-css': patch
+'@nl-design-system-candidate/link-css': patch
+'@nl-design-system-candidate/mark-css': patch
+---
+
+Add missing devDependencies so the project can be built on its own.

--- a/packages/components-css/code-block-css/package.json
+++ b/packages/components-css/code-block-css/package.json
@@ -24,5 +24,9 @@
   "scripts": {
     "build": "sass --style=compressed ./src/:./dist/",
     "clean": "rimraf ./dist/"
+  },
+  "devDependencies": {
+    "rimraf": "6.0.1",
+    "sass": "1.89.2"
   }
 }

--- a/packages/components-css/code-css/package.json
+++ b/packages/components-css/code-css/package.json
@@ -24,5 +24,9 @@
   "scripts": {
     "build": "sass --style=compressed ./src/:./dist/",
     "clean": "rimraf ./dist/"
+  },
+  "devDependencies": {
+    "rimraf": "6.0.1",
+    "sass": "1.89.2"
   }
 }

--- a/packages/components-css/color-sample-css/package.json
+++ b/packages/components-css/color-sample-css/package.json
@@ -24,5 +24,9 @@
   "scripts": {
     "build": "sass --style=compressed ./src/:./dist/",
     "clean": "rimraf ./dist/"
+  },
+  "devDependencies": {
+    "rimraf": "6.0.1",
+    "sass": "1.89.2"
   }
 }

--- a/packages/components-css/data-badge-css/package.json
+++ b/packages/components-css/data-badge-css/package.json
@@ -24,5 +24,9 @@
   "scripts": {
     "build": "sass --style=compressed ./src/:./dist/",
     "clean": "rimraf ./dist/"
+  },
+  "devDependencies": {
+    "rimraf": "6.0.1",
+    "sass": "1.89.2"
   }
 }

--- a/packages/components-css/heading-css/package.json
+++ b/packages/components-css/heading-css/package.json
@@ -24,5 +24,9 @@
   "scripts": {
     "build": "sass --style=compressed ./src/:./dist/",
     "clean": "rimraf ./dist/"
+  },
+  "devDependencies": {
+    "rimraf": "6.0.1",
+    "sass": "1.89.2"
   }
 }

--- a/packages/components-css/link-css/package.json
+++ b/packages/components-css/link-css/package.json
@@ -24,5 +24,9 @@
   "scripts": {
     "build": "sass --style=compressed ./src/:./dist/",
     "clean": "rimraf ./dist/"
+  },
+  "devDependencies": {
+    "rimraf": "6.0.1",
+    "sass": "1.89.2"
   }
 }

--- a/packages/components-css/mark-css/package.json
+++ b/packages/components-css/mark-css/package.json
@@ -24,5 +24,9 @@
   "scripts": {
     "build": "sass --style=compressed ./src/:./dist/",
     "clean": "rimraf ./dist/"
+  },
+  "devDependencies": {
+    "rimraf": "6.0.1",
+    "sass": "1.89.2"
   }
 }

--- a/packages/components-css/number-badge-css/package.json
+++ b/packages/components-css/number-badge-css/package.json
@@ -24,5 +24,9 @@
   "scripts": {
     "build": "sass --style=compressed ./src/:./dist/",
     "clean": "rimraf ./dist/"
+  },
+  "devDependencies": {
+    "rimraf": "6.0.1",
+    "sass": "1.89.2"
   }
 }

--- a/packages/components-css/paragraph-css/package.json
+++ b/packages/components-css/paragraph-css/package.json
@@ -24,5 +24,9 @@
   "scripts": {
     "build": "sass --style=compressed ./src/:./dist/",
     "clean": "rimraf ./dist/"
+  },
+  "devDependencies": {
+    "rimraf": "6.0.1",
+    "sass": "1.89.2"
   }
 }

--- a/packages/components-css/skip-link-css/package.json
+++ b/packages/components-css/skip-link-css/package.json
@@ -24,5 +24,9 @@
   "scripts": {
     "build": "sass --style=compressed ./src/:./dist/",
     "clean": "rimraf ./dist/"
+  },
+  "devDependencies": {
+    "rimraf": "6.0.1",
+    "sass": "1.89.2"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -112,15 +112,50 @@ importers:
         specifier: 3.2.4
         version: 3.2.4(@types/debug@4.1.12)(@types/node@22.17.0)(jsdom@26.1.0)(sass@1.89.2)(yaml@2.8.0)
 
-  packages/components-css/code-block-css: {}
+  packages/components-css/code-block-css:
+    devDependencies:
+      rimraf:
+        specifier: 6.0.1
+        version: 6.0.1
+      sass:
+        specifier: 1.89.2
+        version: 1.89.2
 
-  packages/components-css/code-css: {}
+  packages/components-css/code-css:
+    devDependencies:
+      rimraf:
+        specifier: 6.0.1
+        version: 6.0.1
+      sass:
+        specifier: 1.89.2
+        version: 1.89.2
 
-  packages/components-css/color-sample-css: {}
+  packages/components-css/color-sample-css:
+    devDependencies:
+      rimraf:
+        specifier: 6.0.1
+        version: 6.0.1
+      sass:
+        specifier: 1.89.2
+        version: 1.89.2
 
-  packages/components-css/data-badge-css: {}
+  packages/components-css/data-badge-css:
+    devDependencies:
+      rimraf:
+        specifier: 6.0.1
+        version: 6.0.1
+      sass:
+        specifier: 1.89.2
+        version: 1.89.2
 
-  packages/components-css/heading-css: {}
+  packages/components-css/heading-css:
+    devDependencies:
+      rimraf:
+        specifier: 6.0.1
+        version: 6.0.1
+      sass:
+        specifier: 1.89.2
+        version: 1.89.2
 
   packages/components-css/icon-css:
     devDependencies:
@@ -131,15 +166,50 @@ importers:
         specifier: 1.89.2
         version: 1.89.2
 
-  packages/components-css/link-css: {}
+  packages/components-css/link-css:
+    devDependencies:
+      rimraf:
+        specifier: 6.0.1
+        version: 6.0.1
+      sass:
+        specifier: 1.89.2
+        version: 1.89.2
 
-  packages/components-css/mark-css: {}
+  packages/components-css/mark-css:
+    devDependencies:
+      rimraf:
+        specifier: 6.0.1
+        version: 6.0.1
+      sass:
+        specifier: 1.89.2
+        version: 1.89.2
 
-  packages/components-css/number-badge-css: {}
+  packages/components-css/number-badge-css:
+    devDependencies:
+      rimraf:
+        specifier: 6.0.1
+        version: 6.0.1
+      sass:
+        specifier: 1.89.2
+        version: 1.89.2
 
-  packages/components-css/paragraph-css: {}
+  packages/components-css/paragraph-css:
+    devDependencies:
+      rimraf:
+        specifier: 6.0.1
+        version: 6.0.1
+      sass:
+        specifier: 1.89.2
+        version: 1.89.2
 
-  packages/components-css/skip-link-css: {}
+  packages/components-css/skip-link-css:
+    devDependencies:
+      rimraf:
+        specifier: 6.0.1
+        version: 6.0.1
+      sass:
+        specifier: 1.89.2
+        version: 1.89.2
 
   packages/components-react/code-block-react:
     dependencies:


### PR DESCRIPTION
Add missing devDependencies to the following projects so that they can be built on their own:

- @nl-design-system-candidate/code-block-css
- @nl-design-system-candidate/code-css
- @nl-design-system-candidate/color-sample-css
- @nl-design-system-candidate/data-badge-css
- @nl-design-system-candidate/heading-css
- @nl-design-system-candidate/link-css
- @nl-design-system-candidate/mark-css
- @nl-design-system-candidate/number-badge-css
- @nl-design-system-candidate/paragraph-css
- @nl-design-system-candidate/skip-link-css