### PR TITLE
refactor: add missing devDependencies to *-react

### DIFF
--- a/.changeset/major-hairs-wait.md
+++ b/.changeset/major-hairs-wait.md
@@ -1,0 +1,8 @@
+---
+'@nl-design-system-candidate/code-block-react': patch
+'@nl-design-system-candidate/paragraph-react': patch
+'@nl-design-system-candidate/skip-link-react': patch
+'@nl-design-system-candidate/link-react': patch
+---
+
+Add missing devDependencies so the project can be built on its own.

--- a/packages/components-react/code-block-react/package.json
+++ b/packages/components-react/code-block-react/package.json
@@ -37,10 +37,18 @@
     "typecheck": "tsc"
   },
   "devDependencies": {
+    "@babel/preset-env": "7.28.0",
+    "@babel/preset-react": "7.27.1",
+    "@babel/preset-typescript": "7.27.1",
     "@babel/runtime": "7.28.2",
     "@nl-design-system-candidate/code-block-css": "workspace:*",
+    "@nl-design-system/rollup-config-react-component": "1.0.6",
     "@types/react": "18.3.23",
-    "react": "18.3.1"
+    "react": "18.3.1",
+    "rimraf": "6.0.1",
+    "rollup": "4.46.2",
+    "typescript": "5.9.2",
+    "vitest": "3.2.4"
   },
   "peerDependencies": {
     "@babel/runtime": "^7",

--- a/packages/components-react/link-react/package.json
+++ b/packages/components-react/link-react/package.json
@@ -37,10 +37,18 @@
     "typecheck": "tsc"
   },
   "devDependencies": {
+    "@babel/preset-env": "7.28.0",
+    "@babel/preset-react": "7.27.1",
+    "@babel/preset-typescript": "7.27.1",
     "@babel/runtime": "7.28.2",
     "@nl-design-system-candidate/link-css": "workspace:*",
+    "@nl-design-system/rollup-config-react-component": "1.0.6",
     "@types/react": "18.3.23",
-    "react": "18.3.1"
+    "react": "18.3.1",
+    "rimraf": "6.0.1",
+    "rollup": "4.46.2",
+    "typescript": "5.9.2",
+    "vitest": "3.2.4"
   },
   "peerDependencies": {
     "@babel/runtime": "^7",

--- a/packages/components-react/paragraph-react/package.json
+++ b/packages/components-react/paragraph-react/package.json
@@ -37,10 +37,18 @@
     "typecheck": "tsc"
   },
   "devDependencies": {
+    "@babel/preset-env": "7.28.0",
+    "@babel/preset-react": "7.27.1",
+    "@babel/preset-typescript": "7.27.1",
     "@babel/runtime": "7.28.2",
     "@nl-design-system-candidate/paragraph-css": "workspace:*",
+    "@nl-design-system/rollup-config-react-component": "1.0.6",
     "@types/react": "18.3.23",
-    "react": "18.3.1"
+    "react": "18.3.1",
+    "rimraf": "6.0.1",
+    "rollup": "4.46.2",
+    "typescript": "5.9.2",
+    "vitest": "3.2.4"
   },
   "peerDependencies": {
     "@babel/runtime": "^7",

--- a/packages/components-react/skip-link-react/package.json
+++ b/packages/components-react/skip-link-react/package.json
@@ -37,10 +37,18 @@
     "typecheck": "tsc"
   },
   "devDependencies": {
+    "@babel/preset-env": "7.28.0",
+    "@babel/preset-react": "7.27.1",
+    "@babel/preset-typescript": "7.27.1",
     "@babel/runtime": "7.28.2",
     "@nl-design-system-candidate/skip-link-css": "workspace:*",
+    "@nl-design-system/rollup-config-react-component": "1.0.6",
     "@types/react": "18.3.23",
-    "react": "18.3.1"
+    "react": "18.3.1",
+    "rimraf": "6.0.1",
+    "rollup": "4.46.2",
+    "typescript": "5.9.2",
+    "vitest": "3.2.4"
   },
   "peerDependencies": {
     "@babel/runtime": "^7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -147,18 +147,42 @@ importers:
         specifier: 2.1.1
         version: 2.1.1
     devDependencies:
+      '@babel/preset-env':
+        specifier: 7.28.0
+        version: 7.28.0(@babel/core@7.28.0)
+      '@babel/preset-react':
+        specifier: 7.27.1
+        version: 7.27.1(@babel/core@7.28.0)
+      '@babel/preset-typescript':
+        specifier: 7.27.1
+        version: 7.27.1(@babel/core@7.28.0)
       '@babel/runtime':
         specifier: 7.28.2
         version: 7.28.2
       '@nl-design-system-candidate/code-block-css':
         specifier: workspace:*
         version: link:../../components-css/code-block-css
+      '@nl-design-system/rollup-config-react-component':
+        specifier: 1.0.6
+        version: 1.0.6(@types/babel__core@7.20.5)(postcss@8.5.6)(rollup@4.46.2)(tslib@2.6.3)(typescript@5.9.2)
       '@types/react':
         specifier: 18.3.23
         version: 18.3.23
       react:
         specifier: 18.3.1
         version: 18.3.1
+      rimraf:
+        specifier: 6.0.1
+        version: 6.0.1
+      rollup:
+        specifier: 4.46.2
+        version: 4.46.2
+      typescript:
+        specifier: 5.9.2
+        version: 5.9.2
+      vitest:
+        specifier: 3.2.4
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@22.17.0)(jsdom@26.1.0)(sass@1.89.2)(yaml@2.8.0)
 
   packages/components-react/code-react:
     devDependencies:
@@ -365,18 +389,42 @@ importers:
         specifier: 2.1.1
         version: 2.1.1
     devDependencies:
+      '@babel/preset-env':
+        specifier: 7.28.0
+        version: 7.28.0(@babel/core@7.28.0)
+      '@babel/preset-react':
+        specifier: 7.27.1
+        version: 7.27.1(@babel/core@7.28.0)
+      '@babel/preset-typescript':
+        specifier: 7.27.1
+        version: 7.27.1(@babel/core@7.28.0)
       '@babel/runtime':
         specifier: 7.28.2
         version: 7.28.2
       '@nl-design-system-candidate/link-css':
         specifier: workspace:*
         version: link:../../components-css/link-css
+      '@nl-design-system/rollup-config-react-component':
+        specifier: 1.0.6
+        version: 1.0.6(@types/babel__core@7.20.5)(postcss@8.5.6)(rollup@4.46.2)(tslib@2.6.3)(typescript@5.9.2)
       '@types/react':
         specifier: 18.3.23
         version: 18.3.23
       react:
         specifier: 18.3.1
         version: 18.3.1
+      rimraf:
+        specifier: 6.0.1
+        version: 6.0.1
+      rollup:
+        specifier: 4.46.2
+        version: 4.46.2
+      typescript:
+        specifier: 5.9.2
+        version: 5.9.2
+      vitest:
+        specifier: 3.2.4
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@22.17.0)(jsdom@26.1.0)(sass@1.89.2)(yaml@2.8.0)
 
   packages/components-react/mark-react:
     devDependencies:
@@ -462,18 +510,42 @@ importers:
         specifier: 2.1.1
         version: 2.1.1
     devDependencies:
+      '@babel/preset-env':
+        specifier: 7.28.0
+        version: 7.28.0(@babel/core@7.28.0)
+      '@babel/preset-react':
+        specifier: 7.27.1
+        version: 7.27.1(@babel/core@7.28.0)
+      '@babel/preset-typescript':
+        specifier: 7.27.1
+        version: 7.27.1(@babel/core@7.28.0)
       '@babel/runtime':
         specifier: 7.28.2
         version: 7.28.2
       '@nl-design-system-candidate/paragraph-css':
         specifier: workspace:*
         version: link:../../components-css/paragraph-css
+      '@nl-design-system/rollup-config-react-component':
+        specifier: 1.0.6
+        version: 1.0.6(@types/babel__core@7.20.5)(postcss@8.5.6)(rollup@4.46.2)(tslib@2.6.3)(typescript@5.9.2)
       '@types/react':
         specifier: 18.3.23
         version: 18.3.23
       react:
         specifier: 18.3.1
         version: 18.3.1
+      rimraf:
+        specifier: 6.0.1
+        version: 6.0.1
+      rollup:
+        specifier: 4.46.2
+        version: 4.46.2
+      typescript:
+        specifier: 5.9.2
+        version: 5.9.2
+      vitest:
+        specifier: 3.2.4
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@22.17.0)(jsdom@26.1.0)(sass@1.89.2)(yaml@2.8.0)
 
   packages/components-react/skip-link-react:
     dependencies:
@@ -481,18 +553,42 @@ importers:
         specifier: 2.1.1
         version: 2.1.1
     devDependencies:
+      '@babel/preset-env':
+        specifier: 7.28.0
+        version: 7.28.0(@babel/core@7.28.0)
+      '@babel/preset-react':
+        specifier: 7.27.1
+        version: 7.27.1(@babel/core@7.28.0)
+      '@babel/preset-typescript':
+        specifier: 7.27.1
+        version: 7.27.1(@babel/core@7.28.0)
       '@babel/runtime':
         specifier: 7.28.2
         version: 7.28.2
       '@nl-design-system-candidate/skip-link-css':
         specifier: workspace:*
         version: link:../../components-css/skip-link-css
+      '@nl-design-system/rollup-config-react-component':
+        specifier: 1.0.6
+        version: 1.0.6(@types/babel__core@7.20.5)(postcss@8.5.6)(rollup@4.46.2)(tslib@2.6.3)(typescript@5.9.2)
       '@types/react':
         specifier: 18.3.23
         version: 18.3.23
       react:
         specifier: 18.3.1
         version: 18.3.1
+      rimraf:
+        specifier: 6.0.1
+        version: 6.0.1
+      rollup:
+        specifier: 4.46.2
+        version: 4.46.2
+      typescript:
+        specifier: 5.9.2
+        version: 5.9.2
+      vitest:
+        specifier: 3.2.4
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@22.17.0)(jsdom@26.1.0)(sass@1.89.2)(yaml@2.8.0)
 
   packages/docs/code-block-docs: {}
 


### PR DESCRIPTION
Add missing devDependencies to the following projects so that they can be built on their own:

- @nl-design-system-candidate/code-block-react
- @nl-design-system-candidate/link-react
- @nl-design-system-candidate/paragraph-react
- @nl-design-system-candidate/skip-link-react