### PR TITLE
ci: move codecov to its own file

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -1,0 +1,50 @@
+name: Codecov for pull requests
+
+on:
+  workflow_run:
+    workflows:
+      # Triggered by the Continuous Integration workflow
+      - Continuous Integration
+    types:
+      # Only when the Continuous Integration workflow completes
+      - completed
+
+permissions:
+  # Read the contents of the repo
+  contents: read
+  # Write the result back to the pull request that triggered this workflow
+  checks: write
+
+jobs:
+  coverage:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          # Checkout the head_sha of the pull request that triggered this workflow
+          ref: ${{ github.event.workflow_run.head_sha }}
+
+      - name: Install pnpm package manager
+        uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
+
+      - name: Setup Node.js version and cache
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version-file: .nvmrc
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build
+        run: pnpm run build
+
+      - name: Test
+        run: pnpm run test:coverage
+
+      - uses: codecov/codecov-action@18283e04ce6e62d37312384ff67231eb8fd56d24 # v5.4.3
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -1,4 +1,6 @@
 name: Continuous Integration
+# Upon success triggers:
+# - .github/workflows/codecov.yml
 
 on:
   pull_request:
@@ -112,9 +114,4 @@ jobs:
         run: pnpm run build
 
       - name: Test
-        run: pnpm run test:coverage
-
-      - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@18283e04ce6e62d37312384ff67231eb8fd56d24 # v5.4.3
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
+        run: pnpm run test


### PR DESCRIPTION
Move the codecov action to its own file and make sure it runs when the "Continuous Integration" workflow was succesful.

This should make it possible for the codecov action to run for pull requests from forks and have secrets be available without leaking secrets to the pull request.