### PR TITLE
fix: pull request number

### DIFF
--- a/.github/workflows/changeset-status.yml
+++ b/.github/workflows/changeset-status.yml
@@ -70,7 +70,7 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
-          COMMENT=$(gh api repos/:owner/:repo/issues/${{ github.event.pull_request.number }}/comments --jq ".[] | select(.user.login == \"${{ steps.app-token.outputs.app-slug }}[bot]\") | .id")
+          COMMENT=$(gh api repos/:owner/:repo/issues/${{ github.event.workflow_run.pull_requests[0].number }}/comments --jq ".[] | select(.user.login == \"${{ steps.app-token.outputs.app-slug }}[bot]\") | .id")
           echo "comment=${COMMENT}" | tee -a $GITHUB_OUTPUT
 
       - name: Remove existing comment


### PR DESCRIPTION
Get the pull request number from the workflow_run instead of the pull_request that no longer exists.