### PR TITLE
ci/changeset-status

### DIFF
--- a/.github/workflows/changeset-status.yml
+++ b/.github/workflows/changeset-status.yml
@@ -7,15 +7,7 @@ on:
       - Continuous Integration
     types:
       # Start running parallel to the Continuous Integration workflow
-      - in_progress
-
-permissions:
-  # Read the contents of the repo
-  contents: read
-  # Write the result back to the pull request that triggered this workflow
-  checks: write
-  # Be able to comment on the pull request
-  pull-requests: write
+      - requested
 
 jobs:
   changeset-status:
@@ -27,11 +19,15 @@ jobs:
     if: ${{ !startsWith(github.event.workflow_run.head_branch, 'changeset-release/') && github.actor != 'dependabot[bot]' }}
     steps:
       - name: Create GitHub App Token
-        id: app-token
+        id: app_token
         uses: actions/create-github-app-token@df432ceedc7162793a195dd1713ff69aefc7379e # 2.0.6
         with:
           app-id: ${{ vars.NL_DESIGN_SYSTEM_BOT_APP_ID }}
           private-key: ${{ secrets.NL_DESIGN_SYSTEM_BOT_PRIVATE_KEY }}
+          # Read the contents of the repo
+          permission-contents: read
+          # Write the result back to the pull request that triggered this workflow
+          permission-checks: write
 
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -41,14 +37,22 @@ jobs:
           # a changeset is needed or not.
           fetch-depth: 0
 
-      - name: Start check
+      - name: Start status check
+        id: start_status_check
         env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_TOKEN: ${{ steps.app_token.outputs.token }}
         run: |
-          gh api --method POST repos/:owner/:repo/check-runs \
-            --header "Accept: application/vnd.github+json" \
-            --field head_sha=${{ github.event.workflow_run.head_sha }} \
-            --field name="${{ github.workflow }}" \
+          check_run_id=$(
+            gh api repos/:owner/:repo/check-runs \
+              --method POST \
+              --header "Accept: application/vnd.github+json" \
+              --field head_sha=${{ github.event.workflow_run.head_sha }} \
+              --field name="${{ github.job }}" \
+              --field status="in_progress" \
+              --field started_at="$(date --utc +%Y-%m-%dT%H:%M:%SZ)" \
+              --jq '.id'
+          )
+          echo "check_run_id=${check_run_id}" | tee -a "${GITHUB_OUTPUT}"
 
       - name: Install pnpm package manager
         uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
@@ -56,61 +60,21 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Changset status
-        id: changeset-status
-        run: |
-          if pnpm run changeset:status; then
-            echo "status=0" | tee -a $GITHUB_OUTPUT
-          else
-            echo "status=1" | tee -a $GITHUB_OUTPUT
-          fi
+      - name: Changeset status
+        id: changeset_status
+        run: pnpm run changeset:status
+        continue-on-error: true
 
-      - name: Find existing comment
-        id: find-existing-comment
+      - name: Complete status check
         env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_TOKEN: ${{ steps.app_token.outputs.token }}
+          CHECK_RUN_ID: ${{ steps.start_status_check.outputs.check_run_id }}
         run: |
-          COMMENT=$(gh api repos/:owner/:repo/issues/${{ github.event.workflow_run.pull_requests[0].number }}/comments --jq ".[] | select(.user.login == \"${{ steps.app-token.outputs.app-slug }}[bot]\") | .id")
-          echo "comment=${COMMENT}" | tee -a $GITHUB_OUTPUT
-
-      - name: Remove existing comment
-        if: ${{ steps.find-existing-comment.outputs.comment != '' && steps.changeset-status.outputs.status == 0 }}
-        env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
-        run: |
-          gh api --method DELETE repos/:owner/:repo/issues/comments/${{ steps.find-existing-comment.outputs.comment }}
-          gh api --method POST repos/:owner/:repo/check-runs \
+          gh api repos/:owner/:repo/check-runs/${CHECK_RUN_ID} \
+            --method PATCH \
             --header "Accept: application/vnd.github+json" \
             --field head_sha=${{ github.event.workflow_run.head_sha }} \
-            --field name="${{ github.workflow }}" \
-            --field conclusion="success"
-          exit 0
-
-      - name: Create new comment
-        if: ${{ steps.find-existing-comment.outputs.comment == '' && steps.changeset-status.outputs.status == 1 }}
-        env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
-        run: |
-          gh pr comment ${{ github.event.workflow_run.pull_requests[0].number }} \
-            --body ":warning: Deze pull request mist een changeset terwijl er wel een nodig is :warning:"
-          gh api --method POST repos/:owner/:repo/check-runs \
-            --header "Accept: application/vnd.github+json" \
-            --field head_sha=${{ github.event.workflow_run.head_sha }} \
-            --field name="${{ github.workflow }}" \
-            --field conclusion="failure"
-          exit 1
-
-      - name: Update existing comment
-        if: ${{ steps.find-existing-comment.outputs.comment != '' && steps.changeset-status.outputs.status == 1 }}
-        env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
-        run: |
-          gh pr comment ${{ github.event.workflow_run.pull_requests[0].number }} \
-            --edit-last \
-            --body ":warning: Deze pull request mist nog steeds een changeset terwijl er wel een nodig is. :warning:"
-          gh api --method POST repos/:owner/:repo/check-runs \
-            --header "Accept: application/vnd.github+json" \
-            --field head_sha=${{ github.event.workflow_run.head_sha }} \
-            --field name="${{ github.workflow }}" \
-            --field conclusion="failure"
-          exit 1
+            --field name="${{ github.job }}" \
+            --field status="completed" \
+            --field completed_at="$(date --utc +%Y-%m-%dT%H:%M:%SZ)" \
+            --field conclusion="${{ steps.changeset_status.outcome }}"


### PR DESCRIPTION
Refactor changeset-status so it also works on forks.

Remove the commenting on pull requests, the status check for now either fails or succeeds and this is reported back to the head_sha.