### PR TITLE
fix: remove unnecessary changeset

### DIFF
--- a/.changeset/cuddly-moons-raise.md
+++ b/.changeset/cuddly-moons-raise.md
@@ -1,5 +1,0 @@
----
-'@nl-design-system-candidate/icon-docs': patch
----
-
-Add aliases for Icon.


### PR DESCRIPTION
@nl-design-system-candidate/icon-docs is still private so a changeset is not yet necessary. It first needs a release with a major release changeset.