### PR TITLE
chore: storybook component imports

### DIFF
--- a/packages/storybook-non-conforming/package.json
+++ b/packages/storybook-non-conforming/package.json
@@ -18,6 +18,7 @@
     "@etchteam/storybook-addon-status": "7.0.1",
     "@fontsource/fira-code": "5.2.6",
     "@fontsource/fira-sans": "5.2.6",
+    "@nl-design-system-candidate/paragraph-react": "workspace:*",
     "@nl-design-system-candidate/storybook-shared": "workspace:*",
     "@nl-design-system-unstable/design-tokens-table-react": "1.0.0",
     "@nl-design-system-unstable/tokens-lib": "0.3.0",

--- a/packages/storybook-non-conforming/stories/code-block.stories.tsx
+++ b/packages/storybook-non-conforming/stories/code-block.stories.tsx
@@ -1,7 +1,9 @@
+import { Paragraph } from '@nl-design-system-candidate/paragraph-react/css';
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import packageJSON from '../../../components-react/code-block-react/package.json';
-import { CodeBlock } from '../../../components-react/code-block-react/src/css';
-import { Paragraph } from '../../../components-react/paragraph-react/src/css';
+import type { CSSProperties } from 'react';
+import '../../components-css/code-block-css/src/code-block.scss';
+import packageJSON from '../../components-react/code-block-react/package.json';
+import { CodeBlock } from '../../components-react/code-block-react/src/code-block';
 
 const meta = {
   argTypes: {
@@ -39,7 +41,7 @@ export const GeenVisueelOnderscheid: Story = {
       '--nl-code-block-line-height': 'var(--nl-paragraph-line-height)',
       '--nl-code-block-padding-block': '0',
       '--nl-code-block-padding-inline': '0',
-    },
+    } as CSSProperties,
   },
   decorators: [
     (Story) => (

--- a/packages/storybook-non-conforming/stories/code.stories.tsx
+++ b/packages/storybook-non-conforming/stories/code.stories.tsx
@@ -1,9 +1,10 @@
+import { Paragraph } from '@nl-design-system-candidate/paragraph-react/css';
 import { ExampleBodyTextDecorator } from '@nl-design-system-candidate/storybook-shared/src/ExampleBodyTextDecorator';
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import packageJSON from '../../../components-react/code-react/package.json';
-import { Code } from '../../../components-react/code-react/src/css';
-import { Paragraph } from '../../../components-react/paragraph-react/src/css';
-import componentMarkdown from '../../../docs/code-docs/docs/component.md?raw';
+import '../../components-css/code-css/src/code.scss';
+import packageJSON from '../../components-react/code-react/package.json';
+import { Code } from '../../components-react/code-react/src/code';
+import componentMarkdown from '../../docs/code-docs/docs/component.md?raw';
 
 const meta = {
   argTypes: {

--- a/packages/storybook-non-conforming/stories/mark.stories.tsx
+++ b/packages/storybook-non-conforming/stories/mark.stories.tsx
@@ -1,8 +1,10 @@
+import { Paragraph } from '@nl-design-system-candidate/paragraph-react/css';
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import packageJSON from '../../../components-react/mark-react/package.json';
-import { Mark } from '../../../components-react/mark-react/src/css';
-import { Paragraph } from '../../../components-react/paragraph-react/src/css';
-import componentMarkdown from '../../../docs/mark-docs/docs/component.md?raw';
+import type { CSSProperties } from 'react';
+import componentMarkdown from '../../docs/mark-docs/docs/component.md?raw';
+import '../../components-css/mark-css/src/mark.scss';
+import packageJSON from '../../components-react/mark-react/package.json';
+import { Mark } from '../../components-react/mark-react/src/mark';
 
 const meta = {
   argTypes: {
@@ -74,12 +76,14 @@ In dit voorbeeld is het contrast tussen de achtergrondkleur \`white\` en de voor
   render({ children }) {
     return (
       <div
-        style={{
-          '--nl-mark-background-color': 'yellow',
-          '--nl-mark-color': 'black',
-          backgroundColor: 'white',
-          color: 'black',
-        }}
+        style={
+          {
+            '--nl-mark-background-color': 'yellow',
+            '--nl-mark-color': 'black',
+            backgroundColor: 'white',
+            color: 'black',
+          } as CSSProperties
+        }
       >
         <Paragraph>
           In deze koptekst staat een stukje <Mark>{children}</Mark>.

--- a/packages/storybook-non-conforming/stories/paragraph.stories.tsx
+++ b/packages/storybook-non-conforming/stories/paragraph.stories.tsx
@@ -1,7 +1,8 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import { ReactNode } from 'react';
-import packageJSON from '../../../components-react/paragraph-react/package.json';
-import { Paragraph } from '../../../components-react/paragraph-react/src/css';
+import { CSSProperties, ReactNode } from 'react';
+import '../../components-css/paragraph-css/src/paragraph.scss';
+import packageJSON from '../../components-react/paragraph-react/package.json';
+import { Paragraph } from '../../components-react/paragraph-react/src/paragraph';
 
 const meta = {
   argTypes: {
@@ -242,6 +243,7 @@ export const ParagraphIncorrectDir: Story = {
 export const ParagraphAlignCenter: Story = {
   name: 'Fout: tekst gecentreerd',
   args: {
+    // @ts-expect-error "align" is deprecated in HTML5 but works in many browsers, used here only to point out that it should not be used
     align: 'center',
     children: 'Op brute wĳze ving de schooljuf de quasi-kalme lynx.',
   },
@@ -250,6 +252,7 @@ export const ParagraphAlignCenter: Story = {
 export const ParagraphAlignRight: Story = {
   name: 'Fout: tekst rechts uitgelijnd',
   args: {
+    // @ts-expect-error "align" is deprecated in HTML5 but works in many browsers, used here only to point out that it should not be used
     align: 'right',
     children: 'Op brute wĳze ving de schooljuf de quasi-kalme lynx.',
   },
@@ -257,6 +260,7 @@ export const ParagraphAlignRight: Story = {
 export const ParagraphAlignJustify: Story = {
   name: 'Fout: uitgevulde tekst',
   args: {
+    // @ts-expect-error "align" is deprecated in HTML5 but works in many browsers, used here only to point out that it should not be used
     align: 'justify',
     children:
       'In de laatste dagen, toen ik uit Italië naar Engeland terugkeerde, besloot ik, liever dan al den tijd, dien ik te paard moest zitten, met smakelooze en onwetenschappelijke praatjes te slijten, zoo nu en dan of bij mij zelf over een onderwerp uit onze gemeenschappelijke letteroefeningen na te denken of mij te vermeien in de herinnering aan de even geleerde als dierbare vrienden, die ik hier had achtergelaten. Onder dezen kwam uw beeld, mijn beste Morus, mij zeker het allereerst voor den geest en de herinnering aan U, ofschoon wij ver van elkander waren, was mij even aangenaam, als uw omgang was, toen ik U nog van aangezicht tot aangezicht placht te zien, het aangenaamste—ik mag sterven, als het niet waar is—van al wat mij ooit in mijn leven te beurt is gevallen. Daarom vatte ik, omdat ik meende in allen gevalle iets te moeten doen en die tijd mij weinig geschikt voorkwam om een ernstig onderwerp te overdenken, het plan op een boertige lofrede op Moria (de Zotheid) te houden. “Welke Pallas heeft U op die gedachte gebracht?” zult ge zeggen. Vooreerst deed uw geslachtsnaam Morus mij dit plan opvatten, die even dicht bij het woord Moria komt, als gij ver van de zaak af zijt of liever, volgens aller eenstemmig getuigenis, daarmede volstrekt niets gemeen hebt. Verder vermoedde ik, dat deze speling van ons vernuft bovenal uw goedkeuring zou wegdragen, omdat gij in dergelijke jokkernijen, waarbij, zoo ik goed zie, nergens geleerdheid en geest kan gemist worden, bijzonder veel smaak vindt en in het dagelijksche leven als een Democritus pleegt op te treden. Ofschoon gij door uw buitengewone scherpzinnigheid gewoonlijk hemelsbreed in gevoelen van het gemeene volk verschilt, zijt gij toch door de ongeloofelijke zachtheid en meegaandheid van uw karakter niet alleen in staat om met allerlei menschen in alle omstandigheden des levens om te gaan, maar vindt gij er ook een genot in. Deze kleine verhandeling zult gij daarom gaarne aannemen als een aandenken van uw vriend en gij zult ook haar verdediging gaarne aanvaarden, want zij is u toegewijd en daarom voortaan Uw eigendom, niet het mijne.',
@@ -269,7 +273,7 @@ export const ParagraphSmall: Story = {
     children: 'Op brute wĳze ving de schooljuf de quasi-kalme lynx.',
     style: {
       '--nl-paragraph-font-size': '12px',
-    },
+    } as CSSProperties,
   },
 };
 
@@ -279,7 +283,7 @@ export const ParagraphFixedSize: Story = {
     children: 'Op brute wĳze ving de schooljuf de quasi-kalme lynx.',
     style: {
       '--nl-paragraph-font-size': '16px',
-    },
+    } as CSSProperties,
   },
   decorators: [
     (Story) => (
@@ -310,7 +314,7 @@ export const ParagraphLineHeight: Story = {
       'Allen die zich in Nederland bevinden, worden in gelijke gevallen gelijk behandeld. Discriminatie wegens godsdienst, levensovertuiging, politieke gezindheid, ras, geslacht, handicap, seksuele gerichtheid of op welke grond dan ook, is niet toegestaan.',
     style: {
       '--nl-paragraph-line-height': '24px',
-    },
+    } as CSSProperties,
   },
   decorators: [
     (Story) => (
@@ -407,7 +411,7 @@ export const ParagraphContrast: Story = {
     style: {
       '--nl-paragraph-color': 'silver',
       '--nl-paragraph-font-size': '16px',
-    },
+    } as CSSProperties,
   },
   decorators: [
     (Story) => (

--- a/packages/storybook-test/config/main.ts
+++ b/packages/storybook-test/config/main.ts
@@ -19,7 +19,7 @@ const config: StorybookConfig = {
     name: '@storybook/react-vite',
     options: {},
   },
-  stories: ['../stories/**/*stories.@(ts|tsx)'],
+  stories: ['../stories/*.stories.@(ts|tsx)'],
 };
 
 export default config;

--- a/packages/storybook-test/stories/code-block.stories.tsx
+++ b/packages/storybook-test/stories/code-block.stories.tsx
@@ -1,10 +1,12 @@
-import type { Meta, StoryObj } from '@storybook/react-vite';
+import { Paragraph } from '@nl-design-system-candidate/paragraph-react/css';
 import { ExampleBodyTextDecorator } from '@nl-design-system-candidate/storybook-shared/src/ExampleBodyTextDecorator';
-import packageJSON from '../../../components-react/code-block-react/package.json';
-import { CodeBlock } from '../../../components-react/code-block-react/src/css';
-import { Paragraph } from '../../../components-react/paragraph-react/src/css';
-import componentMarkdown from '../../../docs/code-block-docs/docs/component.md?raw';
-import tokens from '../../../tokens/code-block-tokens/tokens.json';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import type { CSSProperties } from 'react';
+import '../../components-css/code-block-css/src/code-block.scss';
+import packageJSON from '../../components-react/code-block-react/package.json';
+import { CodeBlock } from '../../components-react/code-block-react/src/code-block';
+import componentMarkdown from '../../docs/code-block-docs/docs/component.md?raw';
+import tokens from '../../tokens/code-block-tokens/tokens.json';
 import {
   WCAG22_111_NON_TEXT_CONTENT,
   WCAG22_121_AUDIO_ONLY_AND_VIDEO_ONLY_PRERECORDED,
@@ -61,7 +63,7 @@ import {
   WCAG22_338_ACCESSIBLE_AUTHENTICATION_MINIMUM,
   WCAG22_412_NAME_ROLE_VALUE,
   WCAG22_413_STATUS_MESSAGES,
-} from '../../src/WcagTests';
+} from '../src/WcagTests';
 
 const meta = {
   argTypes: {
@@ -362,7 +364,7 @@ export const FallbackFont: Story = {
     children: `De Code Block moet visueel onderscheidbaar zijn.`,
     style: {
       '--nl-code-block-font-family': '""',
-    },
+    } as CSSProperties,
   },
   globals: {
     storyRootClassname: '',

--- a/packages/storybook-test/stories/code.stories.tsx
+++ b/packages/storybook-test/stories/code.stories.tsx
@@ -1,10 +1,10 @@
-import type { Meta, StoryObj } from '@storybook/react-vite';
+import { Paragraph } from '@nl-design-system-candidate/paragraph-react/css';
 import { ExampleBodyTextDecorator } from '@nl-design-system-candidate/storybook-shared/src/ExampleBodyTextDecorator';
-import packageJSON from '../../../components-react/code-react/package.json';
-import { Code } from '../../../components-react/code-react/src/css';
-import { Paragraph } from '../../../components-react/paragraph-react/src/css';
-import componentMarkdown from '../../../docs/code-docs/docs/component.md?raw';
-import tokens from '../../../tokens/code-tokens/tokens.json';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import '../../components-css/code-css/src/code.scss';
+import packageJSON from '../../components-react/code-react/package.json';
+import { Code } from '../../components-react/code-react/src/code';
+import componentMarkdown from '../../docs/code-docs/docs/component.md?raw';
 import {
   WCAG22_111_NON_TEXT_CONTENT,
   WCAG22_121_AUDIO_ONLY_AND_VIDEO_ONLY_PRERECORDED,
@@ -61,7 +61,8 @@ import {
   WCAG22_338_ACCESSIBLE_AUTHENTICATION_MINIMUM,
   WCAG22_412_NAME_ROLE_VALUE,
   WCAG22_413_STATUS_MESSAGES,
-} from '../../src/WcagTests';
+} from '../src/WcagTests';
+import tokens from '../../tokens/code-tokens/tokens.json';
 
 const meta = {
   argTypes: {

--- a/packages/storybook-test/stories/color-sample.stories.tsx
+++ b/packages/storybook-test/stories/color-sample.stories.tsx
@@ -1,11 +1,12 @@
-import type { Meta, StoryObj } from '@storybook/react-vite';
+import { Paragraph } from '@nl-design-system-candidate/paragraph-react/css';
 import { ExampleBodyTextDecorator } from '@nl-design-system-candidate/storybook-shared/src/ExampleBodyTextDecorator';
+import type { Meta, StoryObj } from '@storybook/react-vite';
 import { useId } from 'react';
-import packageJSON from '../../../components-react/color-sample-react/package.json';
-import { ColorSample } from '../../../components-react/color-sample-react/src/css';
-import { Paragraph } from '../../../components-react/paragraph-react/src/css';
-import componentMarkdown from '../../../docs/color-sample-docs/docs/component.md?raw';
-import tokens from '../../../tokens/color-sample-tokens/tokens.json';
+import '../../components-css/color-sample-css/src/color-sample.scss';
+import packageJSON from '../../components-react/color-sample-react/package.json';
+import { ColorSample } from '../../components-react/color-sample-react/src/color-sample';
+import componentMarkdown from '../../docs/color-sample-docs/docs/component.md?raw';
+import tokens from '../../tokens/color-sample-tokens/tokens.json';
 import {
   WCAG22_111_NON_TEXT_CONTENT,
   WCAG22_121_AUDIO_ONLY_AND_VIDEO_ONLY_PRERECORDED,
@@ -62,7 +63,7 @@ import {
   WCAG22_338_ACCESSIBLE_AUTHENTICATION_MINIMUM,
   WCAG22_412_NAME_ROLE_VALUE,
   WCAG22_413_STATUS_MESSAGES,
-} from '../../src/WcagTests';
+} from '../src/WcagTests';
 
 const meta = {
   argTypes: {

--- a/packages/storybook-test/stories/data-badge.stories.tsx
+++ b/packages/storybook-test/stories/data-badge.stories.tsx
@@ -1,11 +1,12 @@
-import type { Meta, StoryObj } from '@storybook/react-vite';
+import { Heading } from '@nl-design-system-candidate/heading-react/css';
+import { Paragraph } from '@nl-design-system-candidate/paragraph-react/css';
 import { ExampleBodyTextDecorator } from '@nl-design-system-candidate/storybook-shared/src/ExampleBodyTextDecorator';
-import packageJSON from '../../../components-react/data-badge-react/package.json';
-import { DataBadge } from '../../../components-react/data-badge-react/src/css';
-import { Heading } from '../../../components-react/heading-react/src/css';
-import { Paragraph } from '../../../components-react/paragraph-react/src/css';
-import componentMarkdown from '../../../docs/data-badge-docs/docs/component.md?raw';
-import tokens from '../../../tokens/data-badge-tokens/tokens.json';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import '../../components-css/data-badge-css/src/data-badge.scss';
+import packageJSON from '../../components-react/data-badge-react/package.json';
+import { DataBadge } from '../../components-react/data-badge-react/src/data-badge';
+import componentMarkdown from '../../docs/data-badge-docs/docs/component.md?raw';
+import tokens from '../../tokens/data-badge-tokens/tokens.json';
 
 const meta = {
   argTypes: {

--- a/packages/storybook-test/stories/heading.stories.tsx
+++ b/packages/storybook-test/stories/heading.stories.tsx
@@ -1,10 +1,12 @@
-import type { Meta, StoryObj } from '@storybook/react-vite';
+import { Paragraph } from '@nl-design-system-candidate/paragraph-react/css';
 import { ExampleBodyTextDecorator } from '@nl-design-system-candidate/storybook-shared/src/ExampleBodyTextDecorator';
-import packageJSON from '../../../components-react/heading-react/package.json';
-import { Heading } from '../../../components-react/heading-react/src/css';
-import { Paragraph } from '../../../components-react/paragraph-react/src/css';
-import componentMarkdown from '../../../docs/heading-docs/docs/component.md?raw';
-import tokens from '../../../tokens/heading-tokens/tokens.json';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import type { CSSProperties } from 'react';
+import '../../components-css/heading-css/src/heading.scss';
+import packageJSON from '../../components-react/heading-react/package.json';
+import { Heading } from '../../components-react/heading-react/src/heading';
+import componentMarkdown from '../../docs/heading-docs/docs/component.md?raw';
+import tokens from '../../tokens/heading-tokens/tokens.json';
 import {
   WCAG22_111_NON_TEXT_CONTENT,
   WCAG22_121_AUDIO_ONLY_AND_VIDEO_ONLY_PRERECORDED,
@@ -62,7 +64,7 @@ import {
   WCAG22_411_PARSING,
   WCAG22_412_NAME_ROLE_VALUE,
   WCAG22_413_STATUS_MESSAGES,
-} from '../../src/WcagTests';
+} from '../src/WcagTests';
 
 const meta = {
   argTypes: {
@@ -598,21 +600,23 @@ export const HeadingLevelColors: Story = {
   },
   render: () => (
     <div
-      style={{
-        '--nl-heading-level-1-color': 'midnightblue',
-        '--nl-heading-level-1-font-family': 'serif',
-        '--nl-heading-level-2-color': 'maroon',
-        '--nl-heading-level-2-font-family': 'sans-serif',
-        '--nl-heading-level-3-color': 'green',
-        '--nl-heading-level-3-font-family': 'serif',
-        '--nl-heading-level-4-color': 'royalblue',
-        '--nl-heading-level-4-font-family': 'sans-serif',
-        '--nl-heading-level-5-color': 'rebeccapurple',
-        '--nl-heading-level-5-font-family': 'serif',
-        '--nl-heading-level-6-color': 'black',
-        '--nl-heading-level-6-font-family': 'sans-serif',
-        backgroundColor: 'white',
-      }}
+      style={
+        {
+          '--nl-heading-level-1-color': 'midnightblue',
+          '--nl-heading-level-1-font-family': 'serif',
+          '--nl-heading-level-2-color': 'maroon',
+          '--nl-heading-level-2-font-family': 'sans-serif',
+          '--nl-heading-level-3-color': 'green',
+          '--nl-heading-level-3-font-family': 'serif',
+          '--nl-heading-level-4-color': 'royalblue',
+          '--nl-heading-level-4-font-family': 'sans-serif',
+          '--nl-heading-level-5-color': 'rebeccapurple',
+          '--nl-heading-level-5-font-family': 'serif',
+          '--nl-heading-level-6-color': 'black',
+          '--nl-heading-level-6-font-family': 'sans-serif',
+          backgroundColor: 'white',
+        } as CSSProperties
+      }
     >
       <Heading level={1}>Civiel recht in Nederland</Heading>
       <Heading level={2}>Burgerlijk Wetboek</Heading>
@@ -654,20 +658,22 @@ export const HeadingLevelSize: Story = {
   },
   render: () => (
     <div
-      style={{
-        '--nl-heading-level-1-font-size': '4em',
-        '--nl-heading-level-1-line-height': '1.3',
-        '--nl-heading-level-2-font-size': '3em',
-        '--nl-heading-level-2-line-height': '1.4',
-        '--nl-heading-level-3-font-size': '2em',
-        '--nl-heading-level-3-line-height': '1.5',
-        '--nl-heading-level-4-font-size': '1.6em',
-        '--nl-heading-level-4-line-height': '1.6',
-        '--nl-heading-level-5-font-size': '1.4em',
-        '--nl-heading-level-5-line-height': '1.7',
-        '--nl-heading-level-6-font-size': '1.2em',
-        '--nl-heading-level-6-line-height': '1.8',
-      }}
+      style={
+        {
+          '--nl-heading-level-1-font-size': '4em',
+          '--nl-heading-level-1-line-height': '1.3',
+          '--nl-heading-level-2-font-size': '3em',
+          '--nl-heading-level-2-line-height': '1.4',
+          '--nl-heading-level-3-font-size': '2em',
+          '--nl-heading-level-3-line-height': '1.5',
+          '--nl-heading-level-4-font-size': '1.6em',
+          '--nl-heading-level-4-line-height': '1.6',
+          '--nl-heading-level-5-font-size': '1.4em',
+          '--nl-heading-level-5-line-height': '1.7',
+          '--nl-heading-level-6-font-size': '1.2em',
+          '--nl-heading-level-6-line-height': '1.8',
+        } as CSSProperties
+      }
     >
       <Heading level={1}>Civiel recht in Nederland</Heading>
       <Heading level={2}>Burgerlijk Wetboek</Heading>

--- a/packages/storybook-test/stories/icon.stories.tsx
+++ b/packages/storybook-test/stories/icon.stories.tsx
@@ -4,9 +4,9 @@ import { Paragraph } from '@nl-design-system-candidate/paragraph-react/css';
 import type { Decorator, Meta, StoryObj } from '@storybook/react-vite';
 import { IconCalendarEvent, IconChevronRight, IconExternalLink, IconSquareChevronRight } from '@tabler/icons-react';
 import type { CSSProperties } from 'react';
-import '../../../components-css/icon-css/src/icon.scss'; // Let Vite compile the SCSS
-import packageJSON from '../../../components-react/icon-react/package.json';
-import { Icon } from '../../../components-react/icon-react/src/icon'; // Icon without CSS
+import '../../components-css/icon-css/src/icon.scss';
+import packageJSON from '../../components-react/icon-react/package.json';
+import { Icon } from '../../components-react/icon-react/src/icon';
 import {
   WCAG22_111_NON_TEXT_CONTENT,
   WCAG22_121_AUDIO_ONLY_AND_VIDEO_ONLY_PRERECORDED,
@@ -63,7 +63,7 @@ import {
   WCAG22_338_ACCESSIBLE_AUTHENTICATION_MINIMUM,
   WCAG22_412_NAME_ROLE_VALUE,
   WCAG22_413_STATUS_MESSAGES,
-} from '../../src/WcagTests';
+} from '../src/WcagTests';
 
 const meta = {
   args: {

--- a/packages/storybook-test/stories/link.stories.tsx
+++ b/packages/storybook-test/stories/link.stories.tsx
@@ -1,13 +1,14 @@
-import type { Meta, StoryObj } from '@storybook/react-vite';
+import { Heading } from '@nl-design-system-candidate/heading-react/css';
+import { Paragraph } from '@nl-design-system-candidate/paragraph-react/css';
 import { ExampleBodyTextDecorator } from '@nl-design-system-candidate/storybook-shared/src/ExampleBodyTextDecorator';
 import { ParagraphDecorator } from '@nl-design-system-candidate/storybook-shared/src/ParagraphDecorator';
-import { Heading } from '../../../components-react/heading-react/src/css';
-import packageJSON from '../../../components-react/link-react/package.json';
-import { Link } from '../../../components-react/link-react/src/css';
-import { Paragraph } from '../../../components-react/paragraph-react/src/css';
-import componentMarkdown from '../../../docs/link-docs/docs/component.md?raw';
-import tokens from '../../../tokens/link-tokens/tokens.json';
-import '../../../components-css/link-css/src/test.scss';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import '../../components-css/link-css/src/link.scss';
+import '../../components-css/link-css/src/test.scss';
+import packageJSON from '../../components-react/link-react/package.json';
+import { Link } from '../../components-react/link-react/src/link';
+import componentMarkdown from '../../docs/link-docs/docs/component.md?raw';
+import tokens from '../../tokens/link-tokens/tokens.json';
 
 const ExampleImage = () => (
   <svg

--- a/packages/storybook-test/stories/mark.stories.tsx
+++ b/packages/storybook-test/stories/mark.stories.tsx
@@ -1,11 +1,12 @@
-import type { Meta, StoryObj } from '@storybook/react-vite';
+import { Heading } from '@nl-design-system-candidate/heading-react/css';
+import { Paragraph } from '@nl-design-system-candidate/paragraph-react/css';
 import { ExampleBodyTextDecorator } from '@nl-design-system-candidate/storybook-shared/src/ExampleBodyTextDecorator';
-import { Heading } from '../../../components-react/heading-react/src/css';
-import packageJSON from '../../../components-react/mark-react/package.json';
-import { Mark } from '../../../components-react/mark-react/src/css';
-import { Paragraph } from '../../../components-react/paragraph-react/src/css';
-import componentMarkdown from '../../../docs/mark-docs/docs/component.md?raw';
-import tokens from '../../../tokens/mark-tokens/tokens.json';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import '../../components-css/mark-css/src/mark.scss';
+import packageJSON from '../../components-react/mark-react/package.json';
+import { Mark } from '../../components-react/mark-react/src/mark';
+import componentMarkdown from '../../docs/mark-docs/docs/component.md?raw';
+import tokens from '../../tokens/mark-tokens/tokens.json';
 
 const meta = {
   argTypes: {

--- a/packages/storybook-test/stories/number-badge.stories.tsx
+++ b/packages/storybook-test/stories/number-badge.stories.tsx
@@ -1,12 +1,14 @@
 /* eslint-disable react/no-unescaped-entities */
+import { Heading } from '@nl-design-system-candidate/heading-react/css';
+import { Paragraph } from '@nl-design-system-candidate/paragraph-react/css';
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import { Heading } from '../../../components-react/heading-react/src/css';
-import packageJSON from '../../../components-react/number-badge-react/package.json';
-import { NumberBadge } from '../../../components-react/number-badge-react/src/css';
-import { Paragraph } from '../../../components-react/paragraph-react/src/css';
-import componentMarkdown from '../../../docs/number-badge-docs/docs/component.md?raw';
-import tokens from '../../../tokens/number-badge-tokens/tokens.json';
-import '../../../components-css/number-badge-css/dist/test.css';
+import type { CSSProperties } from 'react';
+import '../../components-css/number-badge-css/src/number-badge.scss';
+import '../../components-css/number-badge-css/src/test.scss';
+import packageJSON from '../../components-react/number-badge-react/package.json';
+import { NumberBadge } from '../../components-react/number-badge-react/src/number-badge';
+import componentMarkdown from '../../docs/number-badge-docs/docs/component.md?raw';
+import tokens from '../../tokens/number-badge-tokens/tokens.json';
 
 const meta = {
   argTypes: {
@@ -264,7 +266,7 @@ export const Center: Story = {
       '--nl-number-badge-font-size': '3rem',
       '--nl-number-badge-min-block-size': '10rem',
       '--nl-number-badge-min-inline-size': '10rem',
-    },
+    } as CSSProperties,
     value: 42,
   },
   globals: {
@@ -289,11 +291,13 @@ export const FontRelative: Story = {
   decorators: [
     (Story) => (
       <div
-        style={{
-          '--nl-number-badge-font-size': '0.6em',
-          '--nl-number-badge-padding-block': '0.25em',
-          '--nl-number-badge-padding-inline': '0.25em',
-        }}
+        style={
+          {
+            '--nl-number-badge-font-size': '0.6em',
+            '--nl-number-badge-padding-block': '0.25em',
+            '--nl-number-badge-padding-inline': '0.25em',
+          } as CSSProperties
+        }
       >
         <Heading level={1}>Kopniveau {Story()}</Heading>
         <Paragraph>Er zijn 6 kopniveau's in HTML, die kun je op deze pagina zien.</Paragraph>
@@ -340,7 +344,7 @@ export const FontSizeMinimum: Story = {
       '--nl-number-badge-font-size': '0.6em',
       '--nl-number-badge-padding-block': '0.2em',
       '--nl-number-badge-padding-inline': '0.2em',
-    },
+    } as CSSProperties,
     value: 42,
   },
   decorators: [
@@ -401,7 +405,7 @@ export const NumberBadgeBorder: Story = {
       '--nl-number-badge-background-color': 'whitesmoke',
       '--nl-number-badge-border-color': 'dimgray',
       '--nl-number-badge-color': 'black',
-    },
+    } as CSSProperties,
     value: 42,
   },
   globals: {
@@ -455,7 +459,7 @@ export const NumberBadgeFontStyle: Story = {
       '--nl-number-badge-font-size': '0.6em',
       '--nl-number-badge-padding-block': '0.2em',
       '--nl-number-badge-padding-inline': '0.2em',
-    },
+    } as CSSProperties,
     value: 0,
   },
   decorators: [

--- a/packages/storybook-test/stories/paragraph.stories.tsx
+++ b/packages/storybook-test/stories/paragraph.stories.tsx
@@ -1,14 +1,11 @@
-import type { Meta, StoryObj } from '@storybook/react-vite';
 import { ExampleBodyTextDecorator } from '@nl-design-system-candidate/storybook-shared/src/ExampleBodyTextDecorator';
-import packageJSON from '../../../components-react/paragraph-react/package.json';
-import { Paragraph } from '../../../components-react/paragraph-react/src/css';
-import componentMarkdown from '../../../docs/paragraph-docs/docs/component.md?raw';
-import tokens from '../../../tokens/paragraph-tokens/tokens.json';
-import {
-  LargeLetterSpacingDecorator,
-  LargeLineHeightDecorator,
-  LargeWordSpacingDecorator,
-} from '../../src/TextDecorator';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import '../../components-css/paragraph-css/src/paragraph.scss';
+import packageJSON from '../../components-react/paragraph-react/package.json';
+import { Paragraph } from '../../components-react/paragraph-react/src/paragraph';
+import componentMarkdown from '../../docs/paragraph-docs/docs/component.md?raw';
+import tokens from '../../tokens/paragraph-tokens/tokens.json';
+import { LargeLetterSpacingDecorator, LargeLineHeightDecorator, LargeWordSpacingDecorator } from '../src/TextDecorator';
 import {
   WCAG22_111_NON_TEXT_CONTENT,
   WCAG22_121_AUDIO_ONLY_AND_VIDEO_ONLY_PRERECORDED,
@@ -65,7 +62,7 @@ import {
   WCAG22_338_ACCESSIBLE_AUTHENTICATION_MINIMUM,
   WCAG22_412_NAME_ROLE_VALUE,
   WCAG22_413_STATUS_MESSAGES,
-} from '../../src/WcagTests';
+} from '../src/WcagTests';
 
 const meta = {
   argTypes: {

--- a/packages/storybook-test/stories/skip-link.stories.tsx
+++ b/packages/storybook-test/stories/skip-link.stories.tsx
@@ -1,13 +1,13 @@
+import { Heading } from '@nl-design-system-candidate/heading-react/css';
+import { Paragraph } from '@nl-design-system-candidate/paragraph-react/css';
 import { ExampleBodyTextDecorator } from '@nl-design-system-candidate/storybook-shared/src/ExampleBodyTextDecorator';
 import type { Decorator, Meta, StoryObj } from '@storybook/react-vite';
 import type { PropsWithChildren, ReactNode } from 'react';
-import { Heading } from '../../../components-react/heading-react/src/css';
-import { Paragraph } from '../../../components-react/paragraph-react/src/css';
-import packageJSON from '../../../components-react/skip-link-react/package.json';
-import { SkipLink } from '../../../components-react/skip-link-react/src/css';
-import tokens from '../../../tokens/skip-link-tokens/tokens.json';
-// import the following file last because it is needed for Chromatic test
-import '../../../components-css/skip-link-css/src/test.scss';
+import '../../components-css/skip-link-css/src/skip-link.scss';
+import '../../components-css/skip-link-css/src/test.scss';
+import packageJSON from '../../components-react/skip-link-react/package.json';
+import { SkipLink } from '../../components-react/skip-link-react/src/skip-link';
+import tokens from '../../tokens/skip-link-tokens/tokens.json';
 
 interface ExamplePageProps {
   organisation: ReactNode;

--- a/packages/storybook/package.json
+++ b/packages/storybook/package.json
@@ -21,6 +21,7 @@
   "devDependencies": {
     "@fontsource/fira-sans": "5.2.6",
     "@fontsource/source-serif-pro": "5.2.5",
+    "@nl-design-system-candidate/paragraph-react": "workspace:*",
     "@nl-design-system-candidate/storybook-shared": "workspace:*",
     "@nl-design-system-unstable/voorbeeld-design-tokens": "5.0.0",
     "@storybook/addon-a11y": "9.1.5",

--- a/packages/storybook/stories/code-block.stories.tsx
+++ b/packages/storybook/stories/code-block.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import '../../components-css/code-block-css/src/code-block.scss';
 import packageJSON from '../../components-react/code-block-react/package.json';
-import { CodeBlock } from '../../components-react/code-block-react/src/css';
+import { CodeBlock } from '../../components-react/code-block-react/src/code-block';
 
 const meta = {
   argTypes: {

--- a/packages/storybook/stories/code.stories.tsx
+++ b/packages/storybook/stories/code.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import '../../components-css/code-css/src/code.scss';
 import packageJSON from '../../components-react/code-react/package.json';
-import { Code } from '../../components-react/code-react/src/css';
+import { Code } from '../../components-react/code-react/src/code';
 
 const meta = {
   argTypes: {

--- a/packages/storybook/stories/color-sample.stories.tsx
+++ b/packages/storybook/stories/color-sample.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import '../../components-css/color-sample-css/src/color-sample.scss';
 import packageJSON from '../../components-react/color-sample-react/package.json';
-import { ColorSample } from '../../components-react/color-sample-react/src/css';
+import { ColorSample } from '../../components-react/color-sample-react/src/color-sample';
 
 const meta = {
   argTypes: {

--- a/packages/storybook/stories/data-badge.stories.tsx
+++ b/packages/storybook/stories/data-badge.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import '../../components-css/data-badge-css/src/data-badge.scss';
 import packageJSON from '../../components-react/data-badge-react/package.json';
-import { DataBadge } from '../../components-react/data-badge-react/src/css';
+import { DataBadge } from '../../components-react/data-badge-react/src/data-badge';
 
 const meta = {
   argTypes: {

--- a/packages/storybook/stories/heading.stories.tsx
+++ b/packages/storybook/stories/heading.stories.tsx
@@ -1,8 +1,9 @@
 /* eslint-disable react/no-unescaped-entities */
+import { Paragraph } from '@nl-design-system-candidate/paragraph-react/css';
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import '../../components-css/heading-css/src/heading.scss';
 import packageJSON from '../../components-react/heading-react/package.json';
-import { Heading } from '../../components-react/heading-react/src/css';
-import { Paragraph } from '../../components-react/paragraph-react/src/css';
+import { Heading } from '../../components-react/heading-react/src/heading';
 
 const meta = {
   argTypes: {

--- a/packages/storybook/stories/icon.stories.tsx
+++ b/packages/storybook/stories/icon.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import '../../components-css/icon-css/src/icon.scss';
 import packageJSON from '../../components-react/icon-react/package.json';
-import { Icon } from '../../components-react/icon-react/src/css';
+import { Icon } from '../../components-react/icon-react/src/icon';
 
 const meta = {
   args: {

--- a/packages/storybook/stories/link.stories.tsx
+++ b/packages/storybook/stories/link.stories.tsx
@@ -1,8 +1,9 @@
-import type { Meta, StoryObj } from '@storybook/react-vite';
 import { ExampleBodyTextDecorator } from '@nl-design-system-candidate/storybook-shared/src/ExampleBodyTextDecorator';
 import { ParagraphDecorator } from '@nl-design-system-candidate/storybook-shared/src/ParagraphDecorator';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import '../../components-css/link-css/src/link.scss';
 import packageJSON from '../../components-react/link-react/package.json';
-import { Link } from '../../components-react/link-react/src/css';
+import { Link } from '../../components-react/link-react/src/link';
 import { Paragraph } from '../../components-react/paragraph-react/src/css';
 
 const meta = {

--- a/packages/storybook/stories/mark.stories.tsx
+++ b/packages/storybook/stories/mark.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import '../../components-css/mark-css/src/mark.scss';
 import packageJSON from '../../components-react/mark-react/package.json';
-import { Mark } from '../../components-react/mark-react/src/css';
+import { Mark } from '../../components-react/mark-react/src/mark';
 import { Paragraph } from '../../components-react/paragraph-react/src/css';
 
 const meta = {

--- a/packages/storybook/stories/number-badge.stories.tsx
+++ b/packages/storybook/stories/number-badge.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import '../../components-css/number-badge-css/src/number-badge.scss';
 import packageJSON from '../../components-react/number-badge-react/package.json';
-import { NumberBadge } from '../../components-react/number-badge-react/src/css';
+import { NumberBadge } from '../../components-react/number-badge-react/src/number-badge';
 
 const meta = {
   argTypes: {

--- a/packages/storybook/stories/paragraph.stories.tsx
+++ b/packages/storybook/stories/paragraph.stories.tsx
@@ -1,7 +1,8 @@
-import type { Meta, StoryObj } from '@storybook/react-vite';
 import { ExampleBodyTextDecorator } from '@nl-design-system-candidate/storybook-shared/src/ExampleBodyTextDecorator';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import '../../components-css/paragraph-css/src/paragraph.scss';
 import packageJSON from '../../components-react/paragraph-react/package.json';
-import { Paragraph } from '../../components-react/paragraph-react/src/css';
+import { Paragraph } from '../../components-react/paragraph-react/src/paragraph';
 
 const meta = {
   argTypes: {

--- a/packages/storybook/stories/skip-link.stories.tsx
+++ b/packages/storybook/stories/skip-link.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import '../../components-css/skip-link-css/src/skip-link.scss';
 import packageJSON from '../../components-react/skip-link-react/package.json';
-import { SkipLink } from '../../components-react/skip-link-react/src/css';
+import { SkipLink } from '../../components-react/skip-link-react/src/skip-link';
 
 const meta = {
   argTypes: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -690,6 +690,9 @@ importers:
       '@fontsource/source-serif-pro':
         specifier: 5.2.5
         version: 5.2.5
+      '@nl-design-system-candidate/paragraph-react':
+        specifier: workspace:*
+        version: link:../components-react/paragraph-react
       '@nl-design-system-candidate/storybook-shared':
         specifier: workspace:*
         version: link:../storybook-shared
@@ -747,6 +750,9 @@ importers:
       '@fontsource/fira-sans':
         specifier: 5.2.6
         version: 5.2.6
+      '@nl-design-system-candidate/paragraph-react':
+        specifier: workspace:*
+        version: link:../components-react/paragraph-react
       '@nl-design-system-candidate/storybook-shared':
         specifier: workspace:*
         version: link:../storybook-shared


### PR DESCRIPTION
Import the React component and CSS component code separately in the Storybooks in:

- @nl-design-system-candidate/storybook,
- @nl-design-system-candidate/storybook-test
- @nl-design-system-candidate/storybook-non-conforming

We do this instead of importing the convenience `/css` export that the React components provide. This makes it easier to have a running storybook that automatically updates whilst changes to the React and CSS code can be made with stories automatically updating.

Helper components, usually @nl-design-system-candidate/paragraph-react or @nl-design-system-candidate/heading-react are imported as before, from their `/css` convenience exports. Where needed these were added as an extra devDependency to the storybook's package.json.

Remove the unnecessary component-name subfolder of the "stories" folders in:

- @nl-design-system-candidate/storybook-test
- @nl-design-system-candidate/storybook-non-conforming