### PR TITLE
fix: download artifact to specific directory

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -55,6 +55,7 @@ jobs:
           name: visual-regression-testing
           github-token: ${{ github.token }}
           run-id: ${{ github.event.workflow_run.id }}
+          path: packages/storybook-test/dist/
 
       - name: Chromatic
         uses: chromaui/action@d0795df816d05c4a89c80295303970fddd247cce # v13.1.4


### PR DESCRIPTION
Make sure the visual-regression-testing artifact ends up in packages/storybook-test/dist/ where chromatic expects it.