### PR TITLE
fix: disable TurboSnap

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -67,7 +67,5 @@ jobs:
           storybookBuildDir: packages/storybook-test/dist/
           storybookConfigDir: packages/storybook-test/config/
           exitOnceUploaded: true
-          # Enable TurboSnap
-          onlyChanged: true
         env:
           CHROMATIC_SHA: ${{ env.HEAD_SHA }}


### PR DESCRIPTION
Looks like it's a webpack only thing. See:

https://storybook.js.org/docs/api/cli-options#build

> Write stats JSON to disk.
> Requires Webpack