### PR TITLE
ci: enable npm publishing with OIDC

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,6 +13,7 @@ permissions:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    environment: publish
 
     steps:
       - name: Checkout
@@ -34,6 +35,11 @@ jobs:
 
       - name: Build
         run: pnpm run build
+
+      - name: Set up Node.js that is compatible with OIDC
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
+        with:
+          node-version: 24
 
       - name: Publish to the npm Registry
         uses: changesets/action@e0145edc7d9d8679003495b11f87bd8ef63c0cba # v1.5.3

--- a/.npmrc
+++ b/.npmrc
@@ -2,3 +2,5 @@
 # NOT run. This is more or less in line with pnpm behaviour where pre- and post-install scripts need to be added using
 # pnpm approve-builds
 ignore-scripts=true
+
+provenance=true

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "packageManager": "pnpm@10.17.0+sha512.fce8a3dd29a4ed2ec566fb53efbb04d8c44a0f05bc6f24a73046910fb9c3ce7afa35a0980500668fa3573345bd644644fa98338fa168235c80f4aa17aa17fbef",
   "engines": {
     "//": "Update @types/node to match the highest node version here",
-    "node": ">=20 <=22",
+    "node": ">=20 <=24",
     "pnpm": "^10.16.0"
   },
   "devDependencies": {


### PR DESCRIPTION
All these packages have been configured to require OIDC:
<img width="512" height="301" alt="Screenshot 2025-10-26 at 20 52 44" src="https://github.com/user-attachments/assets/8d9c286f-0e05-4abc-a763-5f6c6842d17f" />

