### PR TITLE
ci: fix workflow concurrency

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -15,7 +15,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.workflow_run.head_branch }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
Some workflows were canceled by unrelated PRs because with workflow completion triggers, github.ref refers to the target branch, rather than the source branch as with PRs
