### PR TITLE
chore(heading): move stories to docs package

### DIFF
--- a/.changeset/late-lamps-act.md
+++ b/.changeset/late-lamps-act.md
@@ -1,0 +1,5 @@
+---
+'@nl-design-system-candidate/heading-docs': minor
+---
+
+Stories toegevoegd als exports zodat deze kunnen worden hergebruikt

--- a/packages/docs/heading-docs/package.json
+++ b/packages/docs/heading-docs/package.json
@@ -11,7 +11,8 @@
     "heading-component"
   ],
   "files": [
-    "./docs/"
+    "./docs/",
+    "./stories/"
   ],
   "repository": {
     "type": "git+ssh",
@@ -21,5 +22,12 @@
   "publishConfig": {
     "access": "public",
     "provenance": true
+  },
+  "devDependencies": {
+    "@nl-design-system-candidate/heading-react": "workspace:*",
+    "@nl-design-system-candidate/paragraph-react": "workspace:*",
+    "@storybook/react-vite": "9.1.5",
+    "@types/react": "18.3.23",
+    "react": "18.3.1"
   }
 }

--- a/packages/docs/heading-docs/stories/heading.react.meta.ts
+++ b/packages/docs/heading-docs/stories/heading.react.meta.ts
@@ -1,0 +1,22 @@
+import type { Meta } from '@storybook/react-vite';
+import { Heading } from '@nl-design-system-candidate/heading-react/css';
+
+const meta = {
+  argTypes: {
+    appearance: {
+      control: { labels: { undefined: '(undefined)' }, type: 'select' },
+      options: [undefined, 'level-1', 'level-2', 'level-3', 'level-4', 'level-5', 'level-6'],
+      table: { category: 'API', type: { summary: 'literal' } },
+    },
+    children: { table: { category: 'API' } },
+    level: {
+      type: { required: true },
+      control: { type: 'select' },
+      options: [1, 2, 3, 4, 5, 6],
+      table: { category: 'API', type: { summary: 'unknown[number]' } },
+    },
+  },
+  component: Heading,
+} satisfies Meta<typeof Heading>;
+
+export default meta;

--- a/packages/docs/heading-docs/stories/heading.stories.tsx
+++ b/packages/docs/heading-docs/stories/heading.stories.tsx
@@ -1,0 +1,65 @@
+/* eslint-disable react/no-unescaped-entities */
+import type { StoryObj } from '@storybook/react-vite';
+import type { HeadingProps } from '@nl-design-system-candidate/heading-react';
+import { Paragraph } from '@nl-design-system-candidate/paragraph-react/css';
+
+type Story = StoryObj<HeadingProps>;
+
+export const Heading1MetMeerdereRegelsTekst: Story = {
+  name: 'Heading 1 met meerdere regels tekst',
+  args: {
+    children: (
+      <>
+        When the pawn hits the conflicts he thinks like a king
+        <br />
+        What he knows throws the blows when he goes to the fight
+        <br />
+        And he'll win the whole thing 'fore he enters the ring
+        <br />
+        There's no body to batter when your mind is your might
+        <br />
+        So when you go solo, you hold your own hand
+        <br />
+        And remember that depth is the greatest of heights
+        <br />
+        And if you know where you stand, then you know where to land
+        <br />
+        And if you fall it won't matter, cuz you'll know that you're right
+      </>
+    ),
+    level: 1,
+  },
+  decorators: (Story) => (
+    <>
+      {Story()}
+      <Paragraph>
+        "When the Pawn..." is the second studio album by the American singer-songwriter Fiona Apple. Released by Epic
+        Records in the United States on November 9, 1999, When the Pawn... was wholly written by Apple, with production
+        by Jon Brion.
+      </Paragraph>
+      <Paragraph>
+        Upon its release, "When the Pawn..." broke the record for longest album title at 444 characters (previously held
+        by a volume in "The Best... Album in the World...Ever!"), though this record was subsequently broken.
+      </Paragraph>
+    </>
+  ),
+  globals: {
+    dir: 'ltr',
+    lang: 'en',
+    title: 'When the Pawn...',
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: `Een Heading (level 1) met een tekst die met line breaks over meerder regels is verdeeld.
+
+Bron: [When the Pawn... - Wikipedia](https://en.wikipedia.org/wiki/When_the_Pawn...)
+
+Dit is een voorbeeld van een Heading met \`<br/>\` elementen, een situatie die soms voorkomt in de praktijk.
+
+Dit voorbeeld voldoet niet aan de best practices van NL Design System om de tekst van de Heading niet te lang te maken.`,
+      },
+    },
+    status: { type: [] },
+  },
+};

--- a/packages/storybook/package.json
+++ b/packages/storybook/package.json
@@ -32,6 +32,7 @@
     "@nl-design-system-candidate/link-react": "workspace:*",
     "@nl-design-system-candidate/paragraph-docs": "workspace:*",
     "@nl-design-system-candidate/number-badge-docs": "workspace:*",
+    "@nl-design-system-candidate/heading-docs": "workspace:*",
     "@nl-design-system-candidate/paragraph-react": "workspace:*",
     "@nl-design-system-candidate/skip-link-docs": "workspace:*",
     "@nl-design-system-candidate/storybook-shared": "workspace:*",

--- a/packages/storybook/stories/heading.stories.tsx
+++ b/packages/storybook/stories/heading.stories.tsx
@@ -1,25 +1,11 @@
-/* eslint-disable react/no-unescaped-entities */
-import { Paragraph } from '@nl-design-system-candidate/paragraph-react/css';
-import type { Meta, StoryObj } from '@storybook/react-vite';
-import '../../components-css/heading-css/src/heading.scss';
+import type { Meta } from '@storybook/react-vite';
 import packageJSON from '../../components-react/heading-react/package.json';
 import { Heading } from '../../components-react/heading-react/src/heading';
+import headingMeta from '@nl-design-system-candidate/heading-docs/stories/heading.react.meta';
+import * as Stories from '@nl-design-system-candidate/heading-docs/stories/heading.stories';
 
 const meta = {
-  argTypes: {
-    appearance: {
-      control: { labels: { undefined: '(undefined)' }, type: 'select' },
-      options: [undefined, 'level-1', 'level-2', 'level-3', 'level-4', 'level-5', 'level-6'],
-      table: { category: 'API' },
-    },
-    children: { table: { category: 'API' } },
-    level: {
-      control: { type: 'select' },
-      options: [1, 2, 3, 4, 5, 6],
-      table: { category: 'API' },
-    },
-  },
-  component: Heading,
+  ...headingMeta,
   parameters: {
     externalLinks: [
       {
@@ -37,63 +23,4 @@ const meta = {
 
 export default meta;
 
-type Story = StoryObj<typeof meta>;
-
-export const HeadingMultiline: Story = {
-  name: 'Heading 1 met meerdere regels tekst',
-  args: {
-    children: (
-      <>
-        When the pawn hits the conflicts he thinks like a king
-        <br />
-        What he knows throws the blows when he goes to the fight
-        <br />
-        And he'll win the whole thing 'fore he enters the ring
-        <br />
-        There's no body to batter when your mind is your might
-        <br />
-        So when you go solo, you hold your own hand
-        <br />
-        And remember that depth is the greatest of heights
-        <br />
-        And if you know where you stand, then you know where to land
-        <br />
-        And if you fall it won't matter, cuz you'll know that you're right
-      </>
-    ),
-    level: 1,
-  },
-  decorators: (Story) => (
-    <>
-      {Story()}
-      <Paragraph>
-        "When the Pawn..." is the second studio album by the American singer-songwriter Fiona Apple. Released by Epic
-        Records in the United States on November 9, 1999, When the Pawn... was wholly written by Apple, with production
-        by Jon Brion.
-      </Paragraph>
-      <Paragraph>
-        Upon its release, "When the Pawn..." broke the record for longest album title at 444 characters (previously held
-        by a volume in "The Best... Album in the World...Ever!"), though this record was subsequently broken.
-      </Paragraph>
-    </>
-  ),
-  globals: {
-    dir: 'ltr',
-    lang: 'en',
-    title: 'When the Pawn...',
-  },
-  parameters: {
-    docs: {
-      description: {
-        story: `Een Heading (level 1) met een tekst die met line breaks over meerder regels is verdeeld.
-
-Bron: [When the Pawn... - Wikipedia](https://en.wikipedia.org/wiki/When_the_Pawn...)
-
-Dit is een voorbeeld van een Heading met \`<br/>\` elementen, een situatie die soms voorkomt in de praktijk.
-
-Dit voorbeeld voldoet niet aan de best practices van NL Design System om de tekst van de Heading niet te lang te maken.`,
-      },
-    },
-    status: { type: [] },
-  },
-};
+export const Heading1MetMeerdereRegelsTekst = Stories.Heading1MetMeerdereRegelsTekst;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -813,7 +813,23 @@ importers:
 
   packages/docs/form-field-label-docs: {}
 
-  packages/docs/heading-docs: {}
+  packages/docs/heading-docs:
+    devDependencies:
+      '@nl-design-system-candidate/heading-react':
+        specifier: workspace:*
+        version: link:../../components-react/heading-react
+      '@nl-design-system-candidate/paragraph-react':
+        specifier: workspace:*
+        version: link:../../components-react/paragraph-react
+      '@storybook/react-vite':
+        specifier: 9.1.5
+        version: 9.1.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.46.2)(storybook@9.1.5(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.1.5(@types/node@22.17.0)(sass@1.89.2)(yaml@2.8.0)))(typescript@5.9.2)(vite@7.1.5(@types/node@22.17.0)(sass@1.89.2)(yaml@2.8.0))
+      '@types/react':
+        specifier: 18.3.23
+        version: 18.3.23
+      react:
+        specifier: 18.3.1
+        version: 18.3.1
 
   packages/docs/icon-docs:
     devDependencies:
@@ -930,6 +946,9 @@ importers:
       '@nl-design-system-candidate/number-badge-docs':
         specifier: workspace:*
         version: link:../docs/number-badge-docs
+      '@nl-design-system-candidate/heading-docs':
+        specifier: workspace:*
+        version: link:../docs/heading-docs
       '@nl-design-system-candidate/paragraph-react':
         specifier: workspace:*
         version: link:../components-react/paragraph-react


### PR DESCRIPTION
closes: #729

## How to test:
De stories in: 
https://candidate-git-chore-move-heading-storie-b12a8e-nl-design-system.vercel.app/?path=/docs/heading--documentatie


moet gelijk zijn aan:
https://nl-design-system.github.io/candidate/?path=/docs/heading--documentatie