### PR TITLE
chore(icon): move stories to docs package

### DIFF
--- a/.changeset/hungry-lands-refuse.md
+++ b/.changeset/hungry-lands-refuse.md
@@ -1,0 +1,5 @@
+---
+'@nl-design-system-candidate/icon-docs': patch
+---
+
+Stories toegevoegd als exports zodat deze kunnen worden hergebruikt

--- a/packages/docs/icon-docs/docs/anatomy/anatomy.md
+++ b/packages/docs/icon-docs/docs/anatomy/anatomy.md
@@ -1,0 +1,3 @@
+<!-- @license CC-1.0 -->
+
+# Anatomie

--- a/packages/docs/icon-docs/package.json
+++ b/packages/docs/icon-docs/package.json
@@ -4,7 +4,8 @@
   "license": "CC0-1.0",
   "homepage": "https://github.com/nl-design-system/candidate/tree/main/packages/docs/icon-docs#readme",
   "files": [
-    "./docs/"
+    "./docs/",
+    "./stories/"
   ],
   "repository": {
     "type": "git+ssh",
@@ -15,5 +16,11 @@
   "publishConfig": {
     "access": "public",
     "provenance": true
+  },
+  "devDependencies": {
+    "@nl-design-system-candidate/icon-react": "workspace:*",
+    "@storybook/react-vite": "9.1.5",
+    "@types/react": "18.3.23",
+    "react": "18.3.1"
   }
 }

--- a/packages/docs/icon-docs/stories/icon.react.meta.ts
+++ b/packages/docs/icon-docs/stories/icon.react.meta.ts
@@ -1,0 +1,40 @@
+import type { Meta } from '@storybook/react-vite';
+import { Icon } from '@nl-design-system-candidate/icon-react/css';
+
+const meta = {
+  argTypes: {
+    bidiMirrored: {
+      control: 'boolean',
+      description:
+        'If `true` flips the icon horizontally in right-to-left layouts. This is useful for directional icons like arrows or chevrons.',
+      table: {
+        type: { summary: 'boolean' },
+      },
+    },
+    size: {
+      control: { type: 'radio' },
+      options: ['em', 'ex', 'lh'],
+      table: {
+        type: { summary: 'union' },
+      },
+    },
+    'aria-label': { table: { category: 'API' }, type: 'string' },
+    'aria-labelledby': { table: { category: 'API' }, type: 'string' },
+    // Hide children as it's a React component which cannot be displayed nicely in the Storybook UI
+    children: { table: { disable: true } },
+    className: { table: { category: 'API' }, type: 'string' },
+    dir: {
+      control: { labels: { undefined: '(undefined)' }, type: 'select' },
+      options: [undefined, 'rtl', 'ltr', 'auto'],
+      table: { category: 'API' },
+    },
+    role: {
+      control: { labels: { undefined: '(undefined)' }, type: 'select' },
+      options: [undefined, 'img'],
+      table: { category: 'API' },
+    },
+  },
+  component: Icon,
+} satisfies Meta<typeof Icon>;
+
+export default meta;

--- a/packages/docs/icon-docs/stories/icon.stories.tsx
+++ b/packages/docs/icon-docs/stories/icon.stories.tsx
@@ -1,0 +1,29 @@
+import type { StoryObj } from '@storybook/react-vite';
+import type { IconProps } from '@nl-design-system-candidate/icon-react';
+
+type Story = StoryObj<IconProps>;
+
+const Icon = () => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width="24"
+    height="24"
+    fill="none"
+    stroke="currentColor"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    strokeWidth="2"
+    viewBox="0 0 24 24"
+  >
+    <path stroke="none" d="M0 0h24v24H0z" />
+    <path d="M3 12a9 9 0 1 0 18 0 9 9 0 1 0-18 0" />
+    <path d="m10 16.5 2-3 2 3m-2-3v-2l3-1m-6 0 3 1" />
+    <circle cx="12" cy="7.5" r=".5" fill="currentcolor" />
+  </svg>
+);
+
+export const Default: Story = {
+  args: {
+    children: <Icon />,
+  },
+};

--- a/packages/storybook/package.json
+++ b/packages/storybook/package.json
@@ -23,6 +23,7 @@
     "@fontsource/source-serif-pro": "5.2.5",
     "@nl-design-system-candidate/code-docs": "workspace:*",
     "@nl-design-system-candidate/data-badge-docs": "workspace:*",
+    "@nl-design-system-candidate/icon-docs": "workspace:*",
     "@nl-design-system-candidate/paragraph-react": "workspace:*",
     "@nl-design-system-candidate/storybook-shared": "workspace:*",
     "@nl-design-system-unstable/voorbeeld-design-tokens": "6.2.0",

--- a/packages/storybook/stories/icon.stories.tsx
+++ b/packages/storybook/stories/icon.stories.tsx
@@ -1,47 +1,11 @@
-import type { Meta, StoryObj } from '@storybook/react-vite';
-import '../../components-css/icon-css/src/icon.scss';
+import type { Meta } from '@storybook/react-vite';
 import packageJSON from '../../components-react/icon-react/package.json';
-import { Icon } from '../../components-react/icon-react/src/icon';
+import { Icon } from '../../components-react/icon-react';
+import iconMeta from '@nl-design-system-candidate/icon-docs/stories/icon.react.meta';
+import * as Stories from '@nl-design-system-candidate/icon-docs/stories/icon.stories';
 
 const meta = {
-  args: {
-    children: (
-      <svg
-        xmlns="http://www.w3.org/2000/svg"
-        width="24"
-        height="24"
-        fill="none"
-        stroke="currentColor"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-        strokeWidth="2"
-        viewBox="0 0 24 24"
-      >
-        <path stroke="none" d="M0 0h24v24H0z" />
-        <path d="M3 12a9 9 0 1 0 18 0 9 9 0 1 0-18 0" />
-        <path d="m10 16.5 2-3 2 3m-2-3v-2l3-1m-6 0 3 1" />
-        <circle cx="12" cy="7.5" r=".5" fill="currentcolor" />
-      </svg>
-    ),
-  },
-  argTypes: {
-    'aria-label': { table: { category: 'API' }, type: 'string' },
-    'aria-labelledby': { table: { category: 'API' }, type: 'string' },
-    // Hide children as it's a React component which cannot be displayed nicely in the Storybook UI
-    children: { table: { disable: true } },
-    className: { table: { category: 'API' }, type: 'string' },
-    dir: {
-      control: { labels: { undefined: '(undefined)' }, type: 'select' },
-      options: [undefined, 'rtl', 'ltr', 'auto'],
-      table: { category: 'API' },
-    },
-    role: {
-      control: { labels: { undefined: '(undefined)' }, type: 'select' },
-      options: [undefined, 'img'],
-      table: { category: 'API' },
-    },
-  },
-  component: Icon,
+  ...iconMeta,
   parameters: {
     externalLinks: [
       {
@@ -59,6 +23,4 @@ const meta = {
 
 export default meta;
 
-type Story = StoryObj<typeof meta>;
-
-export const Default: Story = {};
+export const Default = Stories.Default;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -798,7 +798,20 @@ importers:
 
   packages/docs/heading-docs: {}
 
-  packages/docs/icon-docs: {}
+  packages/docs/icon-docs:
+    devDependencies:
+      '@nl-design-system-candidate/icon-react':
+        specifier: workspace:*
+        version: link:../../components-react/icon-react
+      '@storybook/react-vite':
+        specifier: 9.1.5
+        version: 9.1.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.46.2)(storybook@9.1.5(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.1.5(@types/node@22.17.0)(sass@1.89.2)(yaml@2.8.0)))(typescript@5.9.2)(vite@7.1.5(@types/node@22.17.0)(sass@1.89.2)(yaml@2.8.0))
+      '@types/react':
+        specifier: 18.3.23
+        version: 18.3.23
+      react:
+        specifier: 18.3.1
+        version: 18.3.1
 
   packages/docs/link-docs: {}
 
@@ -826,6 +839,9 @@ importers:
       '@nl-design-system-candidate/data-badge-docs':
         specifier: workspace:*
         version: link:../docs/data-badge-docs
+      '@nl-design-system-candidate/icon-docs':
+        specifier: workspace:*
+        version: link:../docs/icon-docs
       '@nl-design-system-candidate/paragraph-react':
         specifier: workspace:*
         version: link:../components-react/paragraph-react

--- a/scripts/templates/docs/stories/new-component.stories.ts
+++ b/scripts/templates/docs/stories/new-component.stories.ts
@@ -1,5 +1,5 @@
 import type { StoryObj } from '@storybook/react-vite';
-import type { NewComponentProps } from '@nl-design-system-candidate/code-react';
+import type { NewComponentProps } from '@nl-design-system-candidate/new-component-react';
 
 type Story = StoryObj<NewComponentProps>;
 


### PR DESCRIPTION
closes: #730

## How to test:
De stories in: 
https://candidate-git-chore-move-icon-stories-t-5fd352-nl-design-system.vercel.app/?path=/docs/icon--documentatie


moet gelijk zijn aan:
https://nl-design-system.github.io/candidate/?path=/docs/icon--documentatie