### PR TITLE
chore(skip-link): move stories to docs package

### DIFF
--- a/.changeset/lucky-snails-travel.md
+++ b/.changeset/lucky-snails-travel.md
@@ -1,0 +1,5 @@
+---
+'@nl-design-system-candidate/skip-link-docs': minor
+---
+
+Stories toegevoegd als exports zodat deze kunnen worden hergebruikt

--- a/packages/docs/skip-link-docs/package.json
+++ b/packages/docs/skip-link-docs/package.json
@@ -11,7 +11,8 @@
     "skip-link-component"
   ],
   "files": [
-    "./docs/"
+    "./docs/",
+    "./stories/"
   ],
   "repository": {
     "type": "git+ssh",
@@ -21,5 +22,9 @@
   "publishConfig": {
     "access": "public",
     "provenance": true
+  },
+  "devDependencies": {
+    "@nl-design-system-candidate/skip-link-react": "workspace:*",
+    "@storybook/react-vite": "9.1.5"
   }
 }

--- a/packages/docs/skip-link-docs/stories/skip-link.react.meta.ts
+++ b/packages/docs/skip-link-docs/stories/skip-link.react.meta.ts
@@ -1,0 +1,20 @@
+import type { Meta } from '@storybook/react-vite';
+import { SkipLink } from '@nl-design-system-candidate/skip-link-react/css';
+
+const meta = {
+  argTypes: {
+    children: { table: { category: 'API' }, type: 'string' },
+    href: {
+      type: { name: 'other', value: 'string', required: true },
+      table: { category: 'API', type: { summary: "AnchorHTMLAttributes['href']" } },
+    },
+    target: {
+      control: { labels: { undefined: '(undefined)' }, type: 'select' },
+      options: [undefined, '_blank', '_parent', '_self', '_top'],
+      table: { category: 'API' },
+    },
+  },
+  component: SkipLink,
+} satisfies Meta<typeof SkipLink>;
+
+export default meta;

--- a/packages/docs/skip-link-docs/stories/skip-link.stories.ts
+++ b/packages/docs/skip-link-docs/stories/skip-link.stories.ts
@@ -1,0 +1,12 @@
+import type { StoryObj } from '@storybook/react-vite';
+import type { SkipLinkProps } from '@nl-design-system-candidate/skip-link-react';
+
+type Story = StoryObj<SkipLinkProps>;
+
+export const SkipLink: Story = {
+  name: 'Skip Link',
+  args: {
+    children: 'Naar de inhoud',
+    href: '#inhoud',
+  },
+};

--- a/packages/storybook/package.json
+++ b/packages/storybook/package.json
@@ -28,6 +28,7 @@
     "@nl-design-system-candidate/icon-docs": "workspace:*",
     "@nl-design-system-candidate/mark-docs": "workspace:*",
     "@nl-design-system-candidate/paragraph-react": "workspace:*",
+    "@nl-design-system-candidate/skip-link-docs": "workspace:*",
     "@nl-design-system-candidate/storybook-shared": "workspace:*",
     "@nl-design-system-unstable/voorbeeld-design-tokens": "6.2.0",
     "@storybook/addon-a11y": "9.1.5",

--- a/packages/storybook/stories/skip-link.stories.tsx
+++ b/packages/storybook/stories/skip-link.stories.tsx
@@ -1,19 +1,11 @@
-import type { Meta, StoryObj } from '@storybook/react-vite';
-import '../../components-css/skip-link-css/src/skip-link.scss';
+import type { Meta } from '@storybook/react-vite';
 import packageJSON from '../../components-react/skip-link-react/package.json';
-import { SkipLink } from '../../components-react/skip-link-react/src/skip-link';
+import { SkipLink as SkipLinkComponent } from '../../components-react/skip-link-react/src/skip-link';
+import skipLinkMeta from '@nl-design-system-candidate/skip-link-docs/stories/skip-link.react.meta';
+import * as Stories from '@nl-design-system-candidate/skip-link-docs/stories/skip-link.stories';
 
 const meta = {
-  argTypes: {
-    children: { table: { category: 'API' }, type: 'string' },
-    href: { table: { category: 'API' } },
-    target: {
-      control: { labels: { undefined: '(undefined)' }, type: 'select' },
-      options: [undefined, '_blank', '_parent', '_self', '_top'],
-      table: { category: 'API' },
-    },
-  },
-  component: SkipLink,
+  ...skipLinkMeta,
   parameters: {
     externalLinks: [
       {
@@ -27,16 +19,8 @@ const meta = {
     ],
   },
   title: 'Skip Link',
-} satisfies Meta<typeof SkipLink>;
+} satisfies Meta<typeof SkipLinkComponent>;
 
 export default meta;
 
-type Story = StoryObj<typeof meta>;
-
-export const Default: Story = {
-  name: 'Skip Link',
-  args: {
-    children: 'Naar de inhoud',
-    href: '#inhoud',
-  },
-};
+export const SkipLink = Stories.SkipLink;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -844,7 +844,14 @@ importers:
 
   packages/docs/paragraph-docs: {}
 
-  packages/docs/skip-link-docs: {}
+  packages/docs/skip-link-docs:
+    devDependencies:
+      '@nl-design-system-candidate/skip-link-react':
+        specifier: workspace:*
+        version: link:../../components-react/skip-link-react
+      '@storybook/react-vite':
+        specifier: 9.1.5
+        version: 9.1.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.46.2)(storybook@9.1.5(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.1.5(@types/node@22.17.0)(sass@1.89.2)(yaml@2.8.0)))(typescript@5.9.2)(vite@7.1.5(@types/node@22.17.0)(sass@1.89.2)(yaml@2.8.0))
 
   packages/docs/text-input-docs: {}
 
@@ -877,6 +884,9 @@ importers:
       '@nl-design-system-candidate/paragraph-react':
         specifier: workspace:*
         version: link:../components-react/paragraph-react
+      '@nl-design-system-candidate/skip-link-docs':
+        specifier: workspace:*
+        version: link:../docs/skip-link-docs
       '@nl-design-system-candidate/storybook-shared':
         specifier: workspace:*
         version: link:../storybook-shared


### PR DESCRIPTION
closes: #735

## How to test:
De stories in: 
https://candidate-git-chore-move-skip-link-stor-70c796-nl-design-system.vercel.app/?path=/docs/skip-link--documentatie


moet gelijk zijn aan:
https://nl-design-system.github.io/candidate/?path=/docs/skip-link--documentatie