### PR TITLE
docs: improve generic issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/001-🐛-bug.md
+++ b/.github/ISSUE_TEMPLATE/001-🐛-bug.md
@@ -1,6 +1,6 @@
 ---
 name: Community - 🐛 Rapporteer een bug
-about: Is de component voldoende gebruikt in verschillende huisstijlen?
+about: Loop je ergens tegenaan?
 title: '{component-name} - {bug omschrijving}'
 labels:
   - bug

--- a/.github/ISSUE_TEMPLATE/002-✨-feature-request.md
+++ b/.github/ISSUE_TEMPLATE/002-✨-feature-request.md
@@ -1,9 +1,9 @@
 ---
-name: Community - 🐛 Rapporteer een bug
-about: Is de component voldoende gebruikt in verschillende huisstijlen?
-title: '{component-name} - {bug omschrijving}'
+name: Community - 🐛 Stel een feature voor
+about: Mis je een functionaliteit of wil je een verbetering voorstellen?
+title: '{component-name} - {feature request omschrijving}'
 labels:
-  - bug
+  - feature request
 ---
 
 ## Omschrijving

--- a/.github/ISSUE_TEMPLATE/003-🗒️-blanco.md
+++ b/.github/ISSUE_TEMPLATE/003-🗒️-blanco.md
@@ -1,4 +1,4 @@
 ---
-name: 🗒️ Blank issue
-about: Create a new issue from scratch
+name: 🗒️ Blanco issue
+about: Maak een issue zonder template aan.
 ---


### PR DESCRIPTION
Feedback die origineel gegeven is op https://github.com/nl-design-system/candidate/pull/889.

Met de volgende suggesties voor labels om aan te maken, omdat deze nog niet bestaan:

> We hebben nog geen bug label, zullen we die aanmaken zoals GitHub 'm als preset heeft, danwel in het Nederlands "Iets werkt niet zoals verwacht"?
<img width="502" height="485" alt="image" src="https://github.com/user-attachments/assets/2e66620e-24ed-492a-89da-ce317e293988" />

> En dan aanmaken als label, bestaat nog niet en niet als GitHub preset, misschien met:
<img width="502" height="491" alt="image" src="https://github.com/user-attachments/assets/19e460af-004e-43ea-b554-a9e1446c3f00" />
