### PR TITLE
feat: tab = 4 spaces

### DIFF
--- a/.changeset/solid-paths-reply.md
+++ b/.changeset/solid-paths-reply.md
@@ -1,0 +1,5 @@
+---
+'@nl-design-system-candidate/code-block-css': minor
+---
+
+Display tabs as 4 spaces instead of 8 spaces.

--- a/packages/components-css/code-block-css/src/_mixin.scss
+++ b/packages/components-css/code-block-css/src/_mixin.scss
@@ -15,6 +15,7 @@
   line-height: var(--nl-code-block-line-height);
   padding-block: var(--nl-code-block-padding-block);
   padding-inline: var(--nl-code-block-padding-inline);
+  tab-size: 4;
   white-space: pre-wrap;
 }
 

--- a/packages/storybook-test/stories/code-block.stories.tsx
+++ b/packages/storybook-test/stories/code-block.stories.tsx
@@ -278,6 +278,33 @@ De volledige inhoud van de Code Block moet leesbaar zijn, ook als de content hee
   },
 };
 
+export const Tabs: Story = {
+  name: 'Code Block met tabs en spaties',
+  args: {
+    children: `<!DOCTYPE html>
+<html lang="nl" dir="ltr">
+\t<head>
+        <meta charset="utf-8" />
+\t\t<title>…</title>
+\t</head>
+\t<body>…</body>
+</html>`,
+  },
+  globals: {
+    dir: 'ltr',
+    lang: 'nl',
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: `Een Code Block waarbij de HTML inspringing heeft met Tab (U+0009) in plaats van Space (U+0020), behalve bij de regel met het \`<meta>\` element: daar is 8 keer Space gebruikt in plaats van 2 keer Tab.
+
+De regels met het \`<meta>\` element en het \`<title>\` element moeten moeten visueel even brede inspringing hebben.`,
+      },
+    },
+  },
+};
+
 export const LangeRegelLineOverflow: Story = {
   name: 'Code Block met 1 extra lange regel, die kan scrollen',
   args: {


### PR DESCRIPTION
`tab-size` is nu Baseline, en ik zie dat veel design system documentatie websites deze instelling hebben op `:root`.