### PR TITLE
feat: support `<summary class="nl-button">`

### DIFF
--- a/packages/components-css/button-css/src/button.scss
+++ b/packages/components-css/button-css/src/button.scss
@@ -25,11 +25,11 @@
     @include mixin.nl-button--forced-colors-disabled;
   }
 
-  .nl-button--pressed {
+  :is(.nl-button--pressed, :where(details[open]) > summary) {
     @include mixin.nl-button--forced-colors-pressed;
   }
 
-  .nl-button--pressed.nl-button--disabled {
+  :is(.nl-button--pressed, :where(details[open]) > summary).nl-button--disabled {
     @include mixin.nl-button--forced-colors-pressed-disabled;
   }
 
@@ -75,19 +75,19 @@
   @include mixin.nl-button--default-active;
 }
 
-.nl-button.nl-button--pressed {
+.nl-button:is(.nl-button--pressed, :where(details[open]) > summary) {
   @include mixin.nl-button--default-pressed;
 }
 
-.nl-button:where(.nl-button--pressed):hover {
+.nl-button:where(:is(.nl-button--pressed, :where(details[open]) > summary)):hover {
   @include mixin.nl-button--default-pressed-hover;
 }
 
-.nl-button:where(.nl-button--pressed):active {
+.nl-button:where(:is(.nl-button--pressed, :where(details[open]) > summary)):active {
   @include mixin.nl-button--default-pressed-active;
 }
 
-.nl-button.nl-button--pressed.nl-button--disabled {
+.nl-button:is(.nl-button--pressed, :where(details[open]) > summary).nl-button--disabled {
   @include mixin.nl-button--default-pressed-disabled;
 }
 
@@ -113,19 +113,19 @@
   @include mixin.nl-button--primary-active;
 }
 
-.nl-button:where(.nl-button--primary).nl-button--pressed {
+.nl-button:where(.nl-button--primary):is(.nl-button--pressed, :where(details[open]) > summary) {
   @include mixin.nl-button--primary-pressed;
 }
 
-.nl-button:where(.nl-button--primary.nl-button--pressed):hover {
+.nl-button:where(.nl-button--primary:is(.nl-button--pressed, :where(details[open]) > summary)):hover {
   @include mixin.nl-button--primary-pressed-hover;
 }
 
-.nl-button:where(.nl-button--primary.nl-button--pressed):active {
+.nl-button:where(.nl-button--primary:is(.nl-button--pressed, :where(details[open]) > summary)):active {
   @include mixin.nl-button--primary-pressed-active;
 }
 
-.nl-button:where(.nl-button--primary).nl-button--pressed.nl-button--disabled {
+.nl-button:where(.nl-button--primary):is(.nl-button--pressed, :where(details[open]) > summary).nl-button--disabled {
   @include mixin.nl-button--primary-pressed-disabled;
 }
 
@@ -146,19 +146,28 @@
   @include mixin.nl-button--primary-positive-active;
 }
 
-.nl-button:where(.nl-button--primary).nl-button--positive.nl-button--pressed {
+.nl-button:where(.nl-button--primary).nl-button--positive:is(.nl-button--pressed, :where(details[open]) > summary) {
   @include mixin.nl-button--primary-positive-pressed;
 }
 
-.nl-button:where(.nl-button--primary.nl-button--positive).nl-button--pressed:hover {
+.nl-button:where(.nl-button--primary.nl-button--positive):is(
+    .nl-button--pressed,
+    :where(details[open]) > summary
+  ):hover {
   @include mixin.nl-button--primary-positive-pressed-hover;
 }
 
-.nl-button:where(.nl-button--primary.nl-button--positive).nl-button--pressed:active {
+.nl-button:where(.nl-button--primary.nl-button--positive):is(
+    .nl-button--pressed,
+    :where(details[open]) > summary
+  ):active {
   @include mixin.nl-button--primary-positive-pressed-active;
 }
 
-.nl-button:where(.nl-button--primary).nl-button--positive.nl-button--pressed.nl-button--disabled {
+.nl-button:where(.nl-button--primary).nl-button--positive:is(
+    .nl-button--pressed,
+    :where(details[open]) > summary
+  ).nl-button--disabled {
   @include mixin.nl-button--primary-positive-pressed-disabled;
 }
 
@@ -179,19 +188,28 @@
   @include mixin.nl-button--primary-negative-active;
 }
 
-.nl-button:where(.nl-button--primary).nl-button--negative.nl-button--pressed {
+.nl-button:where(.nl-button--primary).nl-button--negative:is(.nl-button--pressed, :where(details[open]) > summary) {
   @include mixin.nl-button--primary-negative-pressed;
 }
 
-.nl-button:where(.nl-button--primary.nl-button--negative).nl-button--pressed:hover {
+.nl-button:where(.nl-button--primary.nl-button--negative):is(
+    .nl-button--pressed,
+    :where(details[open]) > summary
+  ):hover {
   @include mixin.nl-button--primary-negative-pressed-hover;
 }
 
-.nl-button:where(.nl-button--primary.nl-button--negative).nl-button--pressed:active {
+.nl-button:where(.nl-button--primary.nl-button--negative):is(
+    .nl-button--pressed,
+    :where(details[open]) > summary
+  ):active {
   @include mixin.nl-button--primary-negative-pressed-active;
 }
 
-.nl-button:where(.nl-button--primary).nl-button--negative.nl-button--pressed.nl-button--disabled {
+.nl-button:where(.nl-button--primary).nl-button--negative:is(
+    .nl-button--pressed,
+    :where(details[open]) > summary
+  ).nl-button--disabled {
   @include mixin.nl-button--primary-negative-pressed-disabled;
 }
 
@@ -212,19 +230,19 @@
   @include mixin.nl-button--secondary-active;
 }
 
-.nl-button:where(.nl-button--secondary).nl-button--pressed {
+.nl-button:where(.nl-button--secondary):is(.nl-button--pressed, :where(details[open]) > summary) {
   @include mixin.nl-button--secondary-pressed;
 }
 
-.nl-button:where(.nl-button--secondary.nl-button--pressed):hover {
+.nl-button:where(.nl-button--secondary:is(.nl-button--pressed, :where(details[open]) > summary)):hover {
   @include mixin.nl-button--secondary-pressed-hover;
 }
 
-.nl-button:where(.nl-button--secondary.nl-button--pressed):active {
+.nl-button:where(.nl-button--secondary:is(.nl-button--pressed, :where(details[open]) > summary)):active {
   @include mixin.nl-button--secondary-pressed-active;
 }
 
-.nl-button:where(.nl-button--secondary).nl-button--pressed.nl-button--disabled {
+.nl-button:where(.nl-button--secondary):is(.nl-button--pressed, :where(details[open]) > summary).nl-button--disabled {
   @include mixin.nl-button--secondary-pressed-disabled;
 }
 
@@ -245,19 +263,28 @@
   @include mixin.nl-button--secondary-positive-active;
 }
 
-.nl-button:where(.nl-button--secondary).nl-button--positive.nl-button--pressed {
+.nl-button:where(.nl-button--secondary).nl-button--positive:is(.nl-button--pressed, :where(details[open]) > summary) {
   @include mixin.nl-button--secondary-positive-pressed;
 }
 
-.nl-button:where(.nl-button--secondary.nl-button--positive).nl-button--pressed:hover {
+.nl-button:where(.nl-button--secondary.nl-button--positive):is(
+    .nl-button--pressed,
+    :where(details[open]) > summary
+  ):hover {
   @include mixin.nl-button--secondary-positive-pressed-hover;
 }
 
-.nl-button:where(.nl-button--secondary.nl-button--positive).nl-button--pressed:active {
+.nl-button:where(.nl-button--secondary.nl-button--positive):is(
+    .nl-button--pressed,
+    :where(details[open]) > summary
+  ):active {
   @include mixin.nl-button--secondary-positive-pressed-active;
 }
 
-.nl-button:where(.nl-button--secondary).nl-button--positive.nl-button--pressed.nl-button--disabled {
+.nl-button:where(.nl-button--secondary).nl-button--positive:is(
+    .nl-button--pressed,
+    :where(details[open]) > summary
+  ).nl-button--disabled {
   @include mixin.nl-button--secondary-positive-pressed-disabled;
 }
 
@@ -278,19 +305,28 @@
   @include mixin.nl-button--secondary-negative-active;
 }
 
-.nl-button:where(.nl-button--secondary).nl-button--negative.nl-button--pressed {
+.nl-button:where(.nl-button--secondary).nl-button--negative:is(.nl-button--pressed, :where(details[open]) > summary) {
   @include mixin.nl-button--secondary-negative-pressed;
 }
 
-.nl-button:where(.nl-button--secondary.nl-button--negative).nl-button--pressed:hover {
+.nl-button:where(.nl-button--secondary.nl-button--negative):is(
+    .nl-button--pressed,
+    :where(details[open]) > summary
+  ):hover {
   @include mixin.nl-button--secondary-negative-pressed-hover;
 }
 
-.nl-button:where(.nl-button--secondary.nl-button--negative).nl-button--pressed:active {
+.nl-button:where(.nl-button--secondary.nl-button--negative):is(
+    .nl-button--pressed,
+    :where(details[open]) > summary
+  ):active {
   @include mixin.nl-button--secondary-negative-pressed-active;
 }
 
-.nl-button:where(.nl-button--secondary).nl-button--negative.nl-button--pressed.nl-button--disabled {
+.nl-button:where(.nl-button--secondary).nl-button--negative:is(
+    .nl-button--pressed,
+    :where(details[open]) > summary
+  ).nl-button--disabled {
   @include mixin.nl-button--secondary-negative-pressed-disabled;
 }
 
@@ -311,19 +347,19 @@
   @include mixin.nl-button--subtle-active;
 }
 
-.nl-button:where(.nl-button--subtle).nl-button--pressed {
+.nl-button:where(.nl-button--subtle):is(.nl-button--pressed, :where(details[open]) > summary) {
   @include mixin.nl-button--subtle-pressed;
 }
 
-.nl-button:where(.nl-button--subtle.nl-button--pressed):hover {
+.nl-button:where(.nl-button--subtle:is(.nl-button--pressed, :where(details[open]) > summary)):hover {
   @include mixin.nl-button--subtle-pressed-hover;
 }
 
-.nl-button:where(.nl-button--subtle.nl-button--pressed):active {
+.nl-button:where(.nl-button--subtle:is(.nl-button--pressed, :where(details[open]) > summary)):active {
   @include mixin.nl-button--subtle-pressed-active;
 }
 
-.nl-button:where(.nl-button--subtle).nl-button--pressed.nl-button--disabled {
+.nl-button:where(.nl-button--subtle):is(.nl-button--pressed, :where(details[open]) > summary).nl-button--disabled {
   @include mixin.nl-button--subtle-pressed-disabled;
 }
 
@@ -344,19 +380,28 @@
   @include mixin.nl-button--subtle-positive-active;
 }
 
-.nl-button:where(.nl-button--subtle).nl-button--positive.nl-button--pressed {
+.nl-button:where(.nl-button--subtle).nl-button--positive:is(.nl-button--pressed, :where(details[open]) > summary) {
   @include mixin.nl-button--subtle-positive-pressed;
 }
 
-.nl-button:where(.nl-button--subtle.nl-button--positive).nl-button--pressed:hover {
+.nl-button:where(.nl-button--subtle.nl-button--positive):is(
+    .nl-button--pressed,
+    :where(details[open]) > summary
+  ):hover {
   @include mixin.nl-button--subtle-positive-pressed-hover;
 }
 
-.nl-button:where(.nl-button--subtle.nl-button--positive).nl-button--pressed:active {
+.nl-button:where(.nl-button--subtle.nl-button--positive):is(
+    .nl-button--pressed,
+    :where(details[open]) > summary
+  ):active {
   @include mixin.nl-button--subtle-positive-pressed-active;
 }
 
-.nl-button:where(.nl-button--subtle).nl-button--positive.nl-button--pressed.nl-button--disabled {
+.nl-button:where(.nl-button--subtle).nl-button--positive:is(
+    .nl-button--pressed,
+    :where(details[open]) > summary
+  ).nl-button--disabled {
   @include mixin.nl-button--subtle-positive-pressed-disabled;
 }
 
@@ -377,19 +422,28 @@
   @include mixin.nl-button--subtle-negative-active;
 }
 
-.nl-button:where(.nl-button--subtle).nl-button--negative.nl-button--pressed {
+.nl-button:where(.nl-button--subtle).nl-button--negative:is(.nl-button--pressed, :where(details[open]) > summary) {
   @include mixin.nl-button--subtle-negative-pressed;
 }
 
-.nl-button:where(.nl-button--subtle.nl-button--negative).nl-button--pressed:hover {
+.nl-button:where(.nl-button--subtle.nl-button--negative):is(
+    .nl-button--pressed,
+    :where(details[open]) > summary
+  ):hover {
   @include mixin.nl-button--subtle-negative-pressed-hover;
 }
 
-.nl-button:where(.nl-button--subtle.nl-button--negative).nl-button--pressed:active {
+.nl-button:where(.nl-button--subtle.nl-button--negative):is(
+    .nl-button--pressed,
+    :where(details[open]) > summary
+  ):active {
   @include mixin.nl-button--subtle-negative-pressed-active;
 }
 
-.nl-button:where(.nl-button--subtle).nl-button--negative.nl-button--pressed.nl-button--disabled {
+.nl-button:where(.nl-button--subtle).nl-button--negative:is(
+    .nl-button--pressed,
+    :where(details[open]) > summary
+  ).nl-button--disabled {
   @include mixin.nl-button--subtle-negative-pressed-disabled;
 }
 

--- a/packages/storybook-test/stories/button.stories.tsx
+++ b/packages/storybook-test/stories/button.stories.tsx
@@ -14,6 +14,7 @@ import {
   IconCheck,
   IconChevronDown,
   IconChevronUp,
+  IconInfoCircleFilled,
   IconLanguage,
   IconLink,
   IconMultiplier2x,
@@ -2656,10 +2657,12 @@ Test deze functionaliteit door het formulier met de eerste button te verzenden. 
   },
 };
 
-const DivButton = ({
+const CustomButton = ({
+  Component = 'div',
   label,
   iconStart,
   iconEnd,
+  iconOnly,
   children,
   pressed,
   purpose,
@@ -2667,9 +2670,9 @@ const DivButton = ({
   hint,
   className,
   ...args
-}: ButtonProps) => {
+}: ButtonProps & { Component: 'div' | 'summary' }) => {
   return (
-    <div
+    <Component
       role="button"
       tabIndex={0}
       className={clsx('nl-button', className, {
@@ -2680,6 +2683,7 @@ const DivButton = ({
         'nl-button--subtle': purpose === 'subtle',
         'nl-button--positive': Boolean(purpose) && hint === 'positive',
         'nl-button--negative': Boolean(purpose) && hint === 'negative',
+        'nl-button--icon-only': iconOnly,
       })}
       {...args}
     >
@@ -2687,7 +2691,7 @@ const DivButton = ({
       {label && <span className="nl-button__label">{label}</span>}
       {children}
       {iconEnd && <span className="nl-button__icon-end">{iconEnd}</span>}
-    </div>
+    </Component>
   );
 };
 
@@ -2753,7 +2757,7 @@ Een \`div\` is standaard niet bedienbaar met het toetsenbord. Om te beginnen moe
       ],
     },
   },
-  render: DivButton,
+  render: CustomButton,
 };
 
 export const DecorativeButtonContentEditable: Story = {
@@ -2802,7 +2806,7 @@ De Button zelf moet niet focusbaar zijn, omdat dit element niet interactief is, 
       ],
     },
   },
-  render: DivButton,
+  render: CustomButton,
 };
 
 export const DecorativeButtonDisabled: Story = {
@@ -2848,7 +2852,7 @@ De Button is niet interactief, de button is decoratief.`,
       ],
     },
   },
-  render: DivButton,
+  render: CustomButton,
 };
 
 export const DecorativeButtonPressed: Story = {
@@ -2894,7 +2898,7 @@ De Button is niet interactief, de button is decoratief.`,
       ],
     },
   },
-  render: DivButton,
+  render: CustomButton,
 };
 
 const EditIconButton = ({ ...args }: ButtonProps) => {
@@ -2988,7 +2992,7 @@ export const ButtonIconEditable: Story = {
 
     return (
       <>
-        <DivButton
+        <CustomButton
           {...args}
           {...updatedArgs}
           iconStart={
@@ -3368,6 +3372,79 @@ export const ButtonKlein: Story = {
           'De button is 24 pixels hoog en breed, maar doordat met `border-radius` de button rond is gemaakt is het zichtbare oppervlakte minder dan 24 x 24 = 576 pixels. Het aanwijzergebied is wel vierkant en 24 x 24 pixels groot, dus je kunt de button aanklikken net buiten zichtbare button naast het afgeronde hoekje.',
       },
     },
+  },
+};
+
+export const ButtonSummary: Story = {
+  name: 'Button op het summary element',
+  args: {
+    purpose: 'primary',
+    iconStart: (
+      <Icon role="img" aria-label="Toevoegen">
+        <IconPlus />
+      </Icon>
+    ),
+    iconEnd: (
+      <Icon role="img" aria-label="Winkelmandje">
+        <IconShoppingCart />
+      </Icon>
+    ),
+    label: undefined,
+    'aria-pressed': 'false',
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: `Button met twee informatieve iconen. Na het activeren van de knop krijgt de knop de state "pressed", en verandert de alternatieve tekst van het linkse icoon van "Toevoegen" naar "Toegevoegd". Het rechtse icoon blijft hetzelfde.`,
+      },
+    },
+  },
+  render: function Render(args) {
+    return (
+      <details>
+        <CustomButton Component="summary" {...args} />
+        <div>fokdokfpaosdkfasd</div>
+      </details>
+    );
+  },
+};
+
+export const ButtonLabelSummary: Story = {
+  name: 'Button op het summary element',
+  args: {
+    purpose: 'subtle',
+    iconStart: (
+      <Icon role="img" aria-label="Informatie">
+        <IconInfoCircleFilled />
+      </Icon>
+    ),
+    iconOnly: true,
+    label: undefined,
+    style: {
+      '--nl-button-border-radius': '9999px',
+      '--nl-button-min-block-size': '24px',
+      '--nl-button-min-inline-size': '24px',
+      '--nl-button-icon-size': '16px',
+      '--nl-button-icon-only-padding-inline-start': '0',
+      '--nl-button-icon-only-padding-inline-end': '0',
+      '--nl-button-icon-only-padding-block-end': '0',
+      '--nl-button-icon-only-padding-block-start': '0',
+    },
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: `Button met twee informatieve iconen. Na het activeren van de knop krijgt de knop de state "pressed", en verandert de alternatieve tekst van het linkse icoon van "Toevoegen" naar "Toegevoegd". Het rechtse icoon blijft hetzelfde.`,
+      },
+    },
+  },
+  render: function Render(args) {
+    return (
+      <details>
+        <CustomButton Component="summary" {...args} />
+        <div>fokdokfpaosdkfasd</div>
+      </details>
+    );
   },
 };
 


### PR DESCRIPTION
This allows existing Toggletip implementations in the community to simply use `nl-button`

Preview:
- https://candidate-storybook-test-git-feat-detai-887e01-nl-design-system.vercel.app/?path=/story/componenten-button--button-summary
- https://candidate-storybook-test-git-feat-detai-887e01-nl-design-system.vercel.app/?path=/story/componenten-button--button-label-summary

For example:

- https://nl-design-system.github.io/rvo/?path=/docs/componenten-expandable-content--documentatie
- https://rijkshuisstijl-community.vercel.app/?path=/docs/css-toggletip--docs