### PR TITLE
fix: remove font-size token from Code

### DIFF
--- a/.changeset/puny-eels-buy.md
+++ b/.changeset/puny-eels-buy.md
@@ -1,0 +1,8 @@
+---
+'@nl-design-system-candidate/code-css': major
+'@nl-design-system-candidate/code-tokens': major
+'@nl-design-system-candidate/code-react': major
+---
+
+Breaking change: removed the `nl.code.font-size` token.
+The token was problematic because it caused very small letters when Code was used inside a Heading.

--- a/packages/components-css/code-css/src/_mixin.scss
+++ b/packages/components-css/code-css/src/_mixin.scss
@@ -2,7 +2,6 @@
   background-color: var(--nl-code-background-color);
   color: var(--nl-code-color);
   font-family: var(--nl-code-font-family, monospace), monospace; // always offer monospace as a fallback
-  font-size: var(--nl-code-font-size, inherit);
   hyphens: none;
   white-space: pre-wrap;
 }

--- a/packages/storybook-test/stories/code.stories.tsx
+++ b/packages/storybook-test/stories/code.stories.tsx
@@ -1,7 +1,7 @@
+import { Heading } from '@nl-design-system-candidate/heading-react/css';
 import { Paragraph } from '@nl-design-system-candidate/paragraph-react/css';
 import { ExampleBodyTextDecorator } from '@nl-design-system-candidate/storybook-shared/src/ExampleBodyTextDecorator';
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import '../../components-css/code-css/src/code.scss';
 import packageJSON from '../../components-react/code-react/package.json';
 import { Code } from '../../components-react/code-react/src/code';
 import componentMarkdown from '../../docs/code-docs/docs/component.md?raw';
@@ -63,6 +63,7 @@ import {
   WCAG22_413_STATUS_MESSAGES,
 } from '../src/WcagTests';
 import tokens from '../../tokens/code-tokens/tokens.json';
+import '../../components-css/code-css/src/code.scss';
 
 const meta = {
   argTypes: {
@@ -315,5 +316,34 @@ export const WhiteSpaceCharacters: Story = {
       Gebruik het derde argument van deze functie om de hoeveelheid spaties voor inspringing te bepalen:{' '}
       <Code>{'JSON.stringify(json, null, "    ");'}</Code>
     </Paragraph>
+  ),
+};
+
+export const CodeHeading: Story = {
+  name: 'Code in een Heading',
+  decorators: ExampleBodyTextDecorator,
+  globals: {
+    dir: 'ltr',
+    lang: 'nl',
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Een fragment Code die in een heading staat. De Heading heeft grotere letters dan standaardtekst. De lettergrootte van Code past zich aan bij die van de Heading.',
+      },
+    },
+    status: { type: [] },
+  },
+  render: () => (
+    <>
+      <Heading level={1}>
+        De risico's van <Code>font-size</Code> voor inline elementen
+      </Heading>
+      <Paragraph>
+        Wanneer je <Code>font-size</Code> instelt op inline elementen zoals <Code>{'<code>'}</Code>, dan kan het zijn
+        dat de tekst veel te klein wordt wanneer ze in een Heading geplaatst worden.
+      </Paragraph>
+    </>
   ),
 };

--- a/packages/storybook-test/stories/code.stories.tsx
+++ b/packages/storybook-test/stories/code.stories.tsx
@@ -338,7 +338,7 @@ export const CodeHeading: Story = {
   render: () => (
     <>
       <Heading level={1}>
-        De risico's van <Code>font-size</Code> voor inline elementen
+        De risico&apos;s van <Code>font-size</Code> voor inline elementen
       </Heading>
       <Paragraph>
         Wanneer je <Code>font-size</Code> instelt op inline elementen zoals <Code>{'<code>'}</Code>, dan kan het zijn

--- a/packages/tokens/code-tokens/tokens.json
+++ b/packages/tokens/code-tokens/tokens.json
@@ -21,13 +21,6 @@
           "nl.nldesignsystem.figma-implementation": true
         },
         "$type": "fontFamilies"
-      },
-      "font-size": {
-        "$extensions": {
-          "nl.nldesignsystem.css-property-syntax": ["<length>", "<percentage>"],
-          "nl.nldesignsystem.figma-implementation": true
-        },
-        "$type": "fontSizes"
       }
     }
   }


### PR DESCRIPTION
Contributes to: https://github.com/nl-design-system/documentatie/issues/3716

Preview: https://candidate-storybook-test-git-fix-remove-cd9399-nl-design-system.vercel.app/?path=/story/componenten-code--code-heading