### PR TITLE
ci: upgrade codecov-action to latest

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -54,7 +54,7 @@ jobs:
 
       - name: Upload coverage to codecov.io
         id: codecov-action
-        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           fail_ci_if_error: true
           override_commit: ${{ github.event.workflow_run.head_sha }}


### PR DESCRIPTION
Older versions seem to have a public key problem that is resolved in 6.0.2/7.0.0
