### PR TITLE
Link naar componentpagina vanaf acceptance-criteria.md

### DIFF
--- a/.changeset/soft-rocks-slide.md
+++ b/.changeset/soft-rocks-slide.md
@@ -1,0 +1,5 @@
+---
+'@nl-design-system-candidate/button-docs': minor
+---
+
+Verwijzingen naar meer uitleg over toegankelijkheidscriteria op de documentatie website toegevoegd.

--- a/packages/docs/button-docs/docs/acceptance-criteria.md
+++ b/packages/docs/button-docs/docs/acceptance-criteria.md
@@ -79,3 +79,15 @@ Het moet mogelijk zijn dat een bezoeker met een enkele aanwijzer (zoals een muis
   - De component kan worden geactiveerd met de `Space` op `keyup`.
   - De `Space` activatie is cancelable door `Tab` te doen en focus te verplaatsen vooraf aan keyup.
 - De component ondersteunt pointer-gedrag waarbij een klik geannuleerd wordt wanneer de gebruiker de aanwijzer indrukt, buiten de component beweegt en pas dan loslaat.
+
+## Acceptatiecriteria toegankelijkheid van de component
+
+- Het is mogelijk om relaties met andere componenten aan te geven.
+- Als je de tekst vergroot tot 200% blijft deze in zijn geheel zichtbaar.
+- Als je de tekstafstand vergroot blijft de tekst in zijn geheel zichtbaar.
+- Je kunt de button focussen met de tabtoets en activeren met de spatiebalk en de entertoets.
+- Wanneer een button de toetsenbordfocus krijgt is de focus zichtbaar.
+- Als de gebruiker een button indrukt met een aanwijzer zoals een muis of vinger, is er de mogelijkheid om de actie te voorkomen of ongedaan te maken.
+- De button heeft een rol van button en het type is instelbaar.
+
+[Meer informatie over deze acceptatiecriteria lees je op de componentpagina op de website van NL Design System.](https://nldesignsystem.nl/button/)

--- a/packages/docs/form-field-description-docs/docs/acceptance-criteria.md
+++ b/packages/docs/form-field-description-docs/docs/acceptance-criteria.md
@@ -34,6 +34,8 @@ Dit zijn de acceptatiecriteria welke HTML elementen en HTML attributen het beste
 - De Form Field Description is standaard niet bereikbaar en bedienbaar met het toetsenbord.
 - De Form Field Description komt standaard niet voor in de focusvolgorde van de pagina.
 
+[Meer informatie over deze acceptatiecriteria lees je op de componentpagina op de website van NL Design System.](https://nldesignsystem.nl/form-field-description/)
+
 ## Acceptatiecriteria APIs van de component
 
 ### CSS API

--- a/packages/docs/form-field-error-message-docs/docs/acceptance-criteria.md
+++ b/packages/docs/form-field-error-message-docs/docs/acceptance-criteria.md
@@ -14,6 +14,8 @@ Er zijn géén specifieke varianten nodig voor de Candidate component.
 - De Form Field Error Message komt standaard niet voor in de focusvolgorde van de pagina.
 - Het is mogelijk om de Form Field Error Message de rol `alert` te geven.
 
+[Meer informatie over deze acceptatiecriteria lees je op de componentpagina op de website van NL Design System.](https://nldesignsystem.nl/form-field-error-message/)
+
 ## Acceptatiecriteria APIs van de component
 
 ### CSS API

--- a/packages/docs/form-field-label-docs/docs/acceptance-criteria.md
+++ b/packages/docs/form-field-label-docs/docs/acceptance-criteria.md
@@ -9,3 +9,5 @@
 - Tekst in het Form Field Label blijft leesbaar wanneer de tekstafstand vergroot wordt.
 - Het Form Field Label is standaard niet bereikbaar en bedienbaar met het toetsenbord.
 - Het Form Field Label komt standaard niet voor in de focusvolgorde van de pagina.
+
+[Meer informatie over deze acceptatiecriteria lees je op de componentpagina op de website van NL Design System.](https://nldesignsystem.nl/form-field-label/)

--- a/packages/docs/ordered-list-docs/docs/acceptance-criteria.md
+++ b/packages/docs/ordered-list-docs/docs/acceptance-criteria.md
@@ -9,3 +9,5 @@
 - Tekst in de Ordered List blijft leesbaar wanneer de tekstafstand vergroot wordt.
 - De Ordered List is standaard niet bereikbaar en bedienbaar met het toetsenbord.
 - De Ordered List komt standaard niet voor in de focusvolgorde van de pagina.
+
+[Meer informatie over deze acceptatiecriteria lees je op de componentpagina op de website van NL Design System.](https://nldesignsystem.nl/ordered-list/)

--- a/packages/docs/text-input-docs/docs/acceptance-criteria.md
+++ b/packages/docs/text-input-docs/docs/acceptance-criteria.md
@@ -128,3 +128,5 @@ Boolean
 - Je kunt de Text Input bereiken en bedienen met het toetsenbord.
 - Als de Text Input de toetsenbordfocus krijgt is de focus zichtbaar.
 - Het is mogelijk de Text Input een toegankelijke naam en de juiste rol te geven en het `value`-attribuut is aanwezig en instelbaar.
+
+[Meer informatie over deze acceptatiecriteria lees je op de componentpagina op de website van NL Design System.](https://nldesignsystem.nl/text-input/)

--- a/packages/docs/unordered-list-docs/docs/acceptance-criteria.md
+++ b/packages/docs/unordered-list-docs/docs/acceptance-criteria.md
@@ -9,3 +9,5 @@
 - Tekst in de Unordered List blijft leesbaar wanneer de tekstafstand vergroot wordt.
 - De Unordered List is standaard niet bereikbaar en bedienbaar met het toetsenbord.
 - De Unordered List komt standaard niet voor in de focusvolgorde van de pagina.
+
+[Meer informatie over deze acceptatiecriteria lees je op de componentpagina op de website van NL Design System.](https://nldesignsystem.nl/unordered-list/)


### PR DESCRIPTION
- Link naar componentpagina toegevoegd in acceptance-criteria.md.
- Voor Button stonden de a11y acceptatiecriteria er nog niet, die toegevoegd.
- Bestand van Text Input verplaatst naar de juiste map.