### PR TITLE
chore: security upgrades for vite, lodash, rollup

### DIFF
--- a/.changeset/ripe-suns-battle.md
+++ b/.changeset/ripe-suns-battle.md
@@ -1,0 +1,15 @@
+---
+'@nl-design-system-candidate/color-sample-react': patch
+'@nl-design-system-candidate/number-badge-react': patch
+'@nl-design-system-candidate/code-block-react': patch
+'@nl-design-system-candidate/data-badge-react': patch
+'@nl-design-system-candidate/paragraph-react': patch
+'@nl-design-system-candidate/skip-link-react': patch
+'@nl-design-system-candidate/heading-react': patch
+'@nl-design-system-candidate/button-react': patch
+'@nl-design-system-candidate/code-react': patch
+'@nl-design-system-candidate/link-react': patch
+'@nl-design-system-candidate/mark-react': patch
+---
+
+Upgrade rollup (fixes GHSA-mw96-cpmx-2vgc)

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "react": "19.2.3",
     "react-dom": "19.2.3",
     "rimraf": "6.1.0",
-    "rollup": "4.53.2",
+    "rollup": "4.62.2",
     "sass": "1.94.1",
     "stylelint": "16.25.0",
     "stylelint-config-standard-scss": "16.0.0",

--- a/packages/components-react/alert-react/package.json
+++ b/packages/components-react/alert-react/package.json
@@ -56,7 +56,7 @@
     "@types/react": "19.2.7",
     "react": "19.2.3",
     "rimraf": "6.1.0",
-    "rollup": "4.53.2",
+    "rollup": "4.62.2",
     "typescript": "5.9.3",
     "vitest": "4.1.8"
   },

--- a/packages/components-react/button-react/package.json
+++ b/packages/components-react/button-react/package.json
@@ -53,7 +53,7 @@
     "@types/react": "19.2.7",
     "react": "19.2.3",
     "rimraf": "6.1.0",
-    "rollup": "4.53.2",
+    "rollup": "4.62.2",
     "typescript": "5.9.3",
     "vitest": "4.1.8"
   },

--- a/packages/components-react/code-block-react/package.json
+++ b/packages/components-react/code-block-react/package.json
@@ -53,7 +53,7 @@
     "@types/react": "19.2.7",
     "react": "19.2.3",
     "rimraf": "6.1.0",
-    "rollup": "4.53.2",
+    "rollup": "4.62.2",
     "typescript": "5.9.3",
     "vitest": "4.1.8"
   },

--- a/packages/components-react/code-react/package.json
+++ b/packages/components-react/code-react/package.json
@@ -53,7 +53,7 @@
     "@types/react": "19.2.7",
     "react": "19.2.3",
     "rimraf": "6.1.0",
-    "rollup": "4.53.2",
+    "rollup": "4.62.2",
     "typescript": "5.9.3",
     "vitest": "4.1.8"
   },

--- a/packages/components-react/color-sample-react/package.json
+++ b/packages/components-react/color-sample-react/package.json
@@ -53,7 +53,7 @@
     "@types/react": "19.2.7",
     "react": "19.2.3",
     "rimraf": "6.1.0",
-    "rollup": "4.53.2",
+    "rollup": "4.62.2",
     "typescript": "5.9.3",
     "vitest": "4.1.8"
   },

--- a/packages/components-react/data-badge-react/package.json
+++ b/packages/components-react/data-badge-react/package.json
@@ -53,7 +53,7 @@
     "@types/react": "19.2.7",
     "react": "19.2.3",
     "rimraf": "6.1.0",
-    "rollup": "4.53.2",
+    "rollup": "4.62.2",
     "typescript": "5.9.3",
     "vitest": "4.1.8"
   },

--- a/packages/components-react/form-field-description-react/package.json
+++ b/packages/components-react/form-field-description-react/package.json
@@ -54,7 +54,7 @@
     "@types/react": "19.2.7",
     "react": "19.2.3",
     "rimraf": "6.1.0",
-    "rollup": "4.53.2",
+    "rollup": "4.62.2",
     "typescript": "5.9.3",
     "vitest": "4.1.8"
   },

--- a/packages/components-react/form-field-error-message-react/package.json
+++ b/packages/components-react/form-field-error-message-react/package.json
@@ -54,7 +54,7 @@
     "@types/react": "19.2.7",
     "react": "19.2.3",
     "rimraf": "6.1.0",
-    "rollup": "4.53.2",
+    "rollup": "4.62.2",
     "typescript": "5.9.3",
     "vitest": "4.1.8"
   },

--- a/packages/components-react/form-field-label-react/package.json
+++ b/packages/components-react/form-field-label-react/package.json
@@ -46,7 +46,7 @@
     "@types/react": "19.2.7",
     "react": "19.2.3",
     "rimraf": "6.1.0",
-    "rollup": "4.53.2",
+    "rollup": "4.62.2",
     "typescript": "5.9.3",
     "vitest": "4.1.8"
   },

--- a/packages/components-react/heading-react/package.json
+++ b/packages/components-react/heading-react/package.json
@@ -53,7 +53,7 @@
     "@types/react": "19.2.7",
     "react": "19.2.3",
     "rimraf": "6.1.0",
-    "rollup": "4.53.2",
+    "rollup": "4.62.2",
     "typescript": "5.9.3",
     "vitest": "4.1.8"
   },

--- a/packages/components-react/icon-react/package.json
+++ b/packages/components-react/icon-react/package.json
@@ -50,7 +50,7 @@
     "@types/react": "19.2.7",
     "react": "19.2.3",
     "rimraf": "6.1.0",
-    "rollup": "4.53.2",
+    "rollup": "4.62.2",
     "typescript": "5.9.3",
     "vitest": "4.1.8"
   },

--- a/packages/components-react/link-react/package.json
+++ b/packages/components-react/link-react/package.json
@@ -53,7 +53,7 @@
     "@types/react": "19.2.7",
     "react": "19.2.3",
     "rimraf": "6.1.0",
-    "rollup": "4.53.2",
+    "rollup": "4.62.2",
     "typescript": "5.9.3",
     "vitest": "4.1.8"
   },

--- a/packages/components-react/mark-react/package.json
+++ b/packages/components-react/mark-react/package.json
@@ -53,7 +53,7 @@
     "@types/react": "19.2.7",
     "react": "19.2.3",
     "rimraf": "6.1.0",
-    "rollup": "4.53.2",
+    "rollup": "4.62.2",
     "typescript": "5.9.3",
     "vitest": "4.1.8"
   },

--- a/packages/components-react/number-badge-react/package.json
+++ b/packages/components-react/number-badge-react/package.json
@@ -53,7 +53,7 @@
     "@types/react": "19.2.7",
     "react": "19.2.3",
     "rimraf": "6.1.0",
-    "rollup": "4.53.2",
+    "rollup": "4.62.2",
     "typescript": "5.9.3",
     "vitest": "4.1.8"
   },

--- a/packages/components-react/ordered-list-react/package.json
+++ b/packages/components-react/ordered-list-react/package.json
@@ -54,7 +54,7 @@
     "@types/react": "19.2.7",
     "react": "19.2.3",
     "rimraf": "6.1.0",
-    "rollup": "4.53.2",
+    "rollup": "4.62.2",
     "typescript": "5.9.3",
     "vitest": "4.1.8"
   },

--- a/packages/components-react/paragraph-react/package.json
+++ b/packages/components-react/paragraph-react/package.json
@@ -53,7 +53,7 @@
     "@types/react": "19.2.7",
     "react": "19.2.3",
     "rimraf": "6.1.0",
-    "rollup": "4.53.2",
+    "rollup": "4.62.2",
     "typescript": "5.9.3",
     "vitest": "4.1.8"
   },

--- a/packages/components-react/skip-link-react/package.json
+++ b/packages/components-react/skip-link-react/package.json
@@ -53,7 +53,7 @@
     "@types/react": "19.2.7",
     "react": "19.2.3",
     "rimraf": "6.1.0",
-    "rollup": "4.53.2",
+    "rollup": "4.62.2",
     "typescript": "5.9.3",
     "vitest": "4.1.8"
   },

--- a/packages/components-react/text-input-react/package.json
+++ b/packages/components-react/text-input-react/package.json
@@ -46,7 +46,7 @@
     "@types/react": "19.2.7",
     "react": "19.2.3",
     "rimraf": "6.1.0",
-    "rollup": "4.53.2",
+    "rollup": "4.62.2",
     "typescript": "5.9.3",
     "vitest": "4.1.8"
   },

--- a/packages/components-react/unordered-list-react/package.json
+++ b/packages/components-react/unordered-list-react/package.json
@@ -54,7 +54,7 @@
     "@types/react": "19.2.7",
     "react": "19.2.3",
     "rimraf": "6.1.0",
-    "rollup": "4.53.2",
+    "rollup": "4.62.2",
     "typescript": "5.9.3",
     "vitest": "4.1.8"
   },

--- a/packages/storybook-non-conforming/package.json
+++ b/packages/storybook-non-conforming/package.json
@@ -34,7 +34,7 @@
     "@types/react": "18.3.26",
     "@whitespace/storybook-addon-html": "8.0.2",
     "clsx": "2.1.1",
-    "lodash-es": "4.17.21",
+    "lodash-es": "4.18.1",
     "prettier": "3.6.2",
     "react-dom": "19.2.3",
     "react": "19.2.3",

--- a/packages/storybook-test/package.json
+++ b/packages/storybook-test/package.json
@@ -41,7 +41,7 @@
     "@utrecht/icon-css": "3.0.1",
     "@whitespace/storybook-addon-html": "8.0.2",
     "clsx": "2.1.1",
-    "lodash-es": "4.17.21",
+    "lodash-es": "4.18.1",
     "prettier": "3.6.2",
     "react-dom": "19.2.3",
     "react": "19.2.3",

--- a/packages/storybook/package.json
+++ b/packages/storybook/package.json
@@ -66,7 +66,7 @@
     "@types/react": "18.3.26",
     "@types/react-dom": "18.3.7",
     "@whitespace/storybook-addon-html": "8.0.2",
-    "lodash-es": "4.17.21",
+    "lodash-es": "4.18.1",
     "prettier": "3.6.2",
     "react": "19.2.3",
     "react-dom": "19.2.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1518,8 +1518,8 @@ importers:
         specifier: 8.0.2
         version: 8.0.2(storybook@9.1.16(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.3.6(@types/node@24.10.4)(sass@1.94.1)(yaml@2.8.1)))
       lodash-es:
-        specifier: 4.17.21
-        version: 4.17.21
+        specifier: 4.18.1
+        version: 4.18.1
       prettier:
         specifier: 3.6.2
         version: 3.6.2
@@ -1596,8 +1596,8 @@ importers:
         specifier: 2.1.1
         version: 2.1.1
       lodash-es:
-        specifier: 4.17.21
-        version: 4.17.21
+        specifier: 4.18.1
+        version: 4.18.1
       prettier:
         specifier: 3.6.2
         version: 3.6.2
@@ -1716,8 +1716,8 @@ importers:
         specifier: 2.1.1
         version: 2.1.1
       lodash-es:
-        specifier: 4.17.21
-        version: 4.17.21
+        specifier: 4.18.1
+        version: 4.18.1
       prettier:
         specifier: 3.6.2
         version: 3.6.2
@@ -5267,6 +5267,9 @@ packages:
 
   lodash-es@4.17.21:
     resolution: {integrity: sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==}
+
+  lodash-es@4.18.1:
+    resolution: {integrity: sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==}
 
   lodash.camelcase@4.3.0:
     resolution: {integrity: sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==}
@@ -10852,6 +10855,8 @@ snapshots:
       p-locate: 6.0.0
 
   lodash-es@4.17.21: {}
+
+  lodash-es@4.18.1: {}
 
   lodash.camelcase@4.3.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,7 @@ settings:
 
 overrides:
   glob: ^11.1.0 || ^12.0.0
+  lodash@>=4.0.0 <=4.17.23: ^4.17.24
   vite@>=7.0.0 <=7.3.4: ^7.3.5
 
 importers:
@@ -5292,8 +5293,8 @@ packages:
   lodash.uniq@4.5.0:
     resolution: {integrity: sha512-xfBaXQd9ryd9dlSDvnvI0lvxfLJlYAZzXomUYzLKtUeOQvOP5piqAWuGtrhWeqaXK9hhoM/iyJc5AV+XfsX3HQ==}
 
-  lodash@4.17.21:
-    resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
+  lodash@4.18.1:
+    resolution: {integrity: sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==}
 
   log-update@6.1.0:
     resolution: {integrity: sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w==}
@@ -8259,7 +8260,7 @@ snapshots:
 
   '@etchteam/storybook-addon-status@7.0.1(storybook@9.1.16(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.3.6(@types/node@24.10.4)(sass@1.94.1)(yaml@2.8.1)))':
     dependencies:
-      lodash: 4.17.21
+      lodash: 4.18.1
       storybook: 9.1.16(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.3.6(@types/node@24.10.4)(sass@1.94.1)(yaml@2.8.1))
 
   '@fontsource/fira-code@5.2.7': {}
@@ -8812,7 +8813,7 @@ snapshots:
       '@types/lodash': 4.17.20
       color-convert: 2.0.1
       dequal: 2.0.3
-      lodash: 4.17.21
+      lodash: 4.18.1
       markdown-to-jsx: 7.7.1(react@19.2.3)
       memoizerific: 1.11.3
       polished: 4.2.2
@@ -9409,7 +9410,7 @@ snapshots:
 
   async@2.6.4:
     dependencies:
-      lodash: 4.17.21
+      lodash: 4.18.1
 
   available-typed-arrays@1.0.7:
     dependencies:
@@ -10872,7 +10873,7 @@ snapshots:
 
   lodash.uniq@4.5.0: {}
 
-  lodash@4.17.21: {}
+  lodash@4.18.1: {}
 
   log-update@6.1.0:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,7 +38,7 @@ importers:
         version: 2.2.0(eslint@9.39.1)(typescript@5.9.3)
       '@nl-design-system/rollup-config-react-component':
         specifier: 1.0.7
-        version: 1.0.7(@types/babel__core@7.20.5)(postcss@8.5.6)(rollup@4.53.2)(tslib@2.6.3)(typescript@5.9.3)
+        version: 1.0.7(@types/babel__core@7.20.5)(postcss@8.5.6)(rollup@4.62.2)(tslib@2.6.3)(typescript@5.9.3)
       '@nl-design-system/tsconfig':
         specifier: 1.0.5
         version: 1.0.5(typescript@5.9.3)
@@ -97,8 +97,8 @@ importers:
         specifier: 6.1.0
         version: 6.1.0
       rollup:
-        specifier: 4.53.2
-        version: 4.53.2
+        specifier: 4.62.2
+        version: 4.62.2
       sass:
         specifier: 1.94.1
         version: 1.94.1
@@ -312,7 +312,7 @@ importers:
         version: 7.28.4
       '@nl-design-system/rollup-config-react-component':
         specifier: 1.0.7
-        version: 1.0.7(@types/babel__core@7.20.5)(postcss@8.5.6)(rollup@4.53.2)(tslib@2.6.3)(typescript@5.9.3)
+        version: 1.0.7(@types/babel__core@7.20.5)(postcss@8.5.6)(rollup@4.62.2)(tslib@2.6.3)(typescript@5.9.3)
       '@types/react':
         specifier: 19.2.7
         version: 19.2.7
@@ -323,8 +323,8 @@ importers:
         specifier: 6.1.0
         version: 6.1.0
       rollup:
-        specifier: 4.53.2
-        version: 4.53.2
+        specifier: 4.62.2
+        version: 4.62.2
       typescript:
         specifier: 5.9.3
         version: 5.9.3
@@ -355,7 +355,7 @@ importers:
         version: 7.28.4
       '@nl-design-system/rollup-config-react-component':
         specifier: 1.0.7
-        version: 1.0.7(@types/babel__core@7.20.5)(postcss@8.5.6)(rollup@4.53.2)(tslib@2.6.3)(typescript@5.9.3)
+        version: 1.0.7(@types/babel__core@7.20.5)(postcss@8.5.6)(rollup@4.62.2)(tslib@2.6.3)(typescript@5.9.3)
       '@types/react':
         specifier: 19.2.7
         version: 19.2.7
@@ -366,8 +366,8 @@ importers:
         specifier: 6.1.0
         version: 6.1.0
       rollup:
-        specifier: 4.53.2
-        version: 4.53.2
+        specifier: 4.62.2
+        version: 4.62.2
       typescript:
         specifier: 5.9.3
         version: 5.9.3
@@ -398,7 +398,7 @@ importers:
         version: 7.28.4
       '@nl-design-system/rollup-config-react-component':
         specifier: 1.0.7
-        version: 1.0.7(@types/babel__core@7.20.5)(postcss@8.5.6)(rollup@4.53.2)(tslib@2.6.3)(typescript@5.9.3)
+        version: 1.0.7(@types/babel__core@7.20.5)(postcss@8.5.6)(rollup@4.62.2)(tslib@2.6.3)(typescript@5.9.3)
       '@types/react':
         specifier: 19.2.7
         version: 19.2.7
@@ -409,8 +409,8 @@ importers:
         specifier: 6.1.0
         version: 6.1.0
       rollup:
-        specifier: 4.53.2
-        version: 4.53.2
+        specifier: 4.62.2
+        version: 4.62.2
       typescript:
         specifier: 5.9.3
         version: 5.9.3
@@ -438,7 +438,7 @@ importers:
         version: 7.28.4
       '@nl-design-system/rollup-config-react-component':
         specifier: 1.0.7
-        version: 1.0.7(@types/babel__core@7.20.5)(postcss@8.5.6)(rollup@4.53.2)(tslib@2.6.3)(typescript@5.9.3)
+        version: 1.0.7(@types/babel__core@7.20.5)(postcss@8.5.6)(rollup@4.62.2)(tslib@2.6.3)(typescript@5.9.3)
       '@types/react':
         specifier: 19.2.7
         version: 19.2.7
@@ -449,8 +449,8 @@ importers:
         specifier: 6.1.0
         version: 6.1.0
       rollup:
-        specifier: 4.53.2
-        version: 4.53.2
+        specifier: 4.62.2
+        version: 4.62.2
       typescript:
         specifier: 5.9.3
         version: 5.9.3
@@ -478,7 +478,7 @@ importers:
         version: 7.28.4
       '@nl-design-system/rollup-config-react-component':
         specifier: 1.0.7
-        version: 1.0.7(@types/babel__core@7.20.5)(postcss@8.5.6)(rollup@4.53.2)(tslib@2.6.3)(typescript@5.9.3)
+        version: 1.0.7(@types/babel__core@7.20.5)(postcss@8.5.6)(rollup@4.62.2)(tslib@2.6.3)(typescript@5.9.3)
       '@types/react':
         specifier: 19.2.7
         version: 19.2.7
@@ -489,8 +489,8 @@ importers:
         specifier: 6.1.0
         version: 6.1.0
       rollup:
-        specifier: 4.53.2
-        version: 4.53.2
+        specifier: 4.62.2
+        version: 4.62.2
       typescript:
         specifier: 5.9.3
         version: 5.9.3
@@ -518,7 +518,7 @@ importers:
         version: 7.28.4
       '@nl-design-system/rollup-config-react-component':
         specifier: 1.0.7
-        version: 1.0.7(@types/babel__core@7.20.5)(postcss@8.5.6)(rollup@4.53.2)(tslib@2.6.3)(typescript@5.9.3)
+        version: 1.0.7(@types/babel__core@7.20.5)(postcss@8.5.6)(rollup@4.62.2)(tslib@2.6.3)(typescript@5.9.3)
       '@types/react':
         specifier: 19.2.7
         version: 19.2.7
@@ -529,8 +529,8 @@ importers:
         specifier: 6.1.0
         version: 6.1.0
       rollup:
-        specifier: 4.53.2
-        version: 4.53.2
+        specifier: 4.62.2
+        version: 4.62.2
       typescript:
         specifier: 5.9.3
         version: 5.9.3
@@ -561,7 +561,7 @@ importers:
         version: 7.28.4
       '@nl-design-system/rollup-config-react-component':
         specifier: 1.0.7
-        version: 1.0.7(@types/babel__core@7.20.5)(postcss@8.5.6)(rollup@4.53.2)(tslib@2.6.3)(typescript@5.9.3)
+        version: 1.0.7(@types/babel__core@7.20.5)(postcss@8.5.6)(rollup@4.62.2)(tslib@2.6.3)(typescript@5.9.3)
       '@types/react':
         specifier: 19.2.7
         version: 19.2.7
@@ -572,8 +572,8 @@ importers:
         specifier: 6.1.0
         version: 6.1.0
       rollup:
-        specifier: 4.53.2
-        version: 4.53.2
+        specifier: 4.62.2
+        version: 4.62.2
       typescript:
         specifier: 5.9.3
         version: 5.9.3
@@ -604,7 +604,7 @@ importers:
         version: 7.28.4
       '@nl-design-system/rollup-config-react-component':
         specifier: 1.0.7
-        version: 1.0.7(@types/babel__core@7.20.5)(postcss@8.5.6)(rollup@4.53.2)(tslib@2.6.3)(typescript@5.9.3)
+        version: 1.0.7(@types/babel__core@7.20.5)(postcss@8.5.6)(rollup@4.62.2)(tslib@2.6.3)(typescript@5.9.3)
       '@types/react':
         specifier: 19.2.7
         version: 19.2.7
@@ -615,8 +615,8 @@ importers:
         specifier: 6.1.0
         version: 6.1.0
       rollup:
-        specifier: 4.53.2
-        version: 4.53.2
+        specifier: 4.62.2
+        version: 4.62.2
       typescript:
         specifier: 5.9.3
         version: 5.9.3
@@ -647,7 +647,7 @@ importers:
         version: 7.28.4
       '@nl-design-system/rollup-config-react-component':
         specifier: 1.0.6
-        version: 1.0.6(@types/babel__core@7.20.5)(postcss@8.5.6)(rollup@4.53.2)(tslib@2.6.3)(typescript@5.9.3)
+        version: 1.0.6(@types/babel__core@7.20.5)(postcss@8.5.6)(rollup@4.62.2)(tslib@2.6.3)(typescript@5.9.3)
       '@types/react':
         specifier: 19.2.7
         version: 19.2.7
@@ -658,8 +658,8 @@ importers:
         specifier: 6.1.0
         version: 6.1.0
       rollup:
-        specifier: 4.53.2
-        version: 4.53.2
+        specifier: 4.62.2
+        version: 4.62.2
       typescript:
         specifier: 5.9.3
         version: 5.9.3
@@ -687,7 +687,7 @@ importers:
         version: 7.28.4
       '@nl-design-system/rollup-config-react-component':
         specifier: 1.0.7
-        version: 1.0.7(@types/babel__core@7.20.5)(postcss@8.5.6)(rollup@4.53.2)(tslib@2.6.3)(typescript@5.9.3)
+        version: 1.0.7(@types/babel__core@7.20.5)(postcss@8.5.6)(rollup@4.62.2)(tslib@2.6.3)(typescript@5.9.3)
       '@types/react':
         specifier: 19.2.7
         version: 19.2.7
@@ -698,8 +698,8 @@ importers:
         specifier: 6.1.0
         version: 6.1.0
       rollup:
-        specifier: 4.53.2
-        version: 4.53.2
+        specifier: 4.62.2
+        version: 4.62.2
       typescript:
         specifier: 5.9.3
         version: 5.9.3
@@ -730,7 +730,7 @@ importers:
         version: 7.28.4
       '@nl-design-system/rollup-config-react-component':
         specifier: 1.0.7
-        version: 1.0.7(@types/babel__core@7.20.5)(postcss@8.5.6)(rollup@4.53.2)(tslib@2.6.3)(typescript@5.9.3)
+        version: 1.0.7(@types/babel__core@7.20.5)(postcss@8.5.6)(rollup@4.62.2)(tslib@2.6.3)(typescript@5.9.3)
       '@types/react':
         specifier: 19.2.7
         version: 19.2.7
@@ -741,8 +741,8 @@ importers:
         specifier: 6.1.0
         version: 6.1.0
       rollup:
-        specifier: 4.53.2
-        version: 4.53.2
+        specifier: 4.62.2
+        version: 4.62.2
       typescript:
         specifier: 5.9.3
         version: 5.9.3
@@ -773,7 +773,7 @@ importers:
         version: 7.28.4
       '@nl-design-system/rollup-config-react-component':
         specifier: 1.0.7
-        version: 1.0.7(@types/babel__core@7.20.5)(postcss@8.5.6)(rollup@4.53.2)(tslib@2.6.3)(typescript@5.9.3)
+        version: 1.0.7(@types/babel__core@7.20.5)(postcss@8.5.6)(rollup@4.62.2)(tslib@2.6.3)(typescript@5.9.3)
       '@types/react':
         specifier: 19.2.7
         version: 19.2.7
@@ -784,8 +784,8 @@ importers:
         specifier: 6.1.0
         version: 6.1.0
       rollup:
-        specifier: 4.53.2
-        version: 4.53.2
+        specifier: 4.62.2
+        version: 4.62.2
       typescript:
         specifier: 5.9.3
         version: 5.9.3
@@ -813,7 +813,7 @@ importers:
         version: 7.28.4
       '@nl-design-system/rollup-config-react-component':
         specifier: 1.0.7
-        version: 1.0.7(@types/babel__core@7.20.5)(postcss@8.5.6)(rollup@4.53.2)(tslib@2.6.3)(typescript@5.9.3)
+        version: 1.0.7(@types/babel__core@7.20.5)(postcss@8.5.6)(rollup@4.62.2)(tslib@2.6.3)(typescript@5.9.3)
       '@types/react':
         specifier: 19.2.7
         version: 19.2.7
@@ -824,8 +824,8 @@ importers:
         specifier: 6.1.0
         version: 6.1.0
       rollup:
-        specifier: 4.53.2
-        version: 4.53.2
+        specifier: 4.62.2
+        version: 4.62.2
       typescript:
         specifier: 5.9.3
         version: 5.9.3
@@ -853,7 +853,7 @@ importers:
         version: 7.28.4
       '@nl-design-system/rollup-config-react-component':
         specifier: 1.0.7
-        version: 1.0.7(@types/babel__core@7.20.5)(postcss@8.5.6)(rollup@4.53.2)(tslib@2.6.3)(typescript@5.9.3)
+        version: 1.0.7(@types/babel__core@7.20.5)(postcss@8.5.6)(rollup@4.62.2)(tslib@2.6.3)(typescript@5.9.3)
       '@types/react':
         specifier: 19.2.7
         version: 19.2.7
@@ -864,8 +864,8 @@ importers:
         specifier: 6.1.0
         version: 6.1.0
       rollup:
-        specifier: 4.53.2
-        version: 4.53.2
+        specifier: 4.62.2
+        version: 4.62.2
       typescript:
         specifier: 5.9.3
         version: 5.9.3
@@ -896,7 +896,7 @@ importers:
         version: 7.28.4
       '@nl-design-system/rollup-config-react-component':
         specifier: 1.0.7
-        version: 1.0.7(@types/babel__core@7.20.5)(postcss@8.5.6)(rollup@4.53.2)(tslib@2.6.3)(typescript@5.9.3)
+        version: 1.0.7(@types/babel__core@7.20.5)(postcss@8.5.6)(rollup@4.62.2)(tslib@2.6.3)(typescript@5.9.3)
       '@types/react':
         specifier: 19.2.7
         version: 19.2.7
@@ -907,8 +907,8 @@ importers:
         specifier: 6.1.0
         version: 6.1.0
       rollup:
-        specifier: 4.53.2
-        version: 4.53.2
+        specifier: 4.62.2
+        version: 4.62.2
       typescript:
         specifier: 5.9.3
         version: 5.9.3
@@ -939,7 +939,7 @@ importers:
         version: 7.28.4
       '@nl-design-system/rollup-config-react-component':
         specifier: 1.0.7
-        version: 1.0.7(@types/babel__core@7.20.5)(postcss@8.5.6)(rollup@4.53.2)(tslib@2.6.3)(typescript@5.9.3)
+        version: 1.0.7(@types/babel__core@7.20.5)(postcss@8.5.6)(rollup@4.62.2)(tslib@2.6.3)(typescript@5.9.3)
       '@types/react':
         specifier: 19.2.7
         version: 19.2.7
@@ -950,8 +950,8 @@ importers:
         specifier: 6.1.0
         version: 6.1.0
       rollup:
-        specifier: 4.53.2
-        version: 4.53.2
+        specifier: 4.62.2
+        version: 4.62.2
       typescript:
         specifier: 5.9.3
         version: 5.9.3
@@ -982,7 +982,7 @@ importers:
         version: 7.28.4
       '@nl-design-system/rollup-config-react-component':
         specifier: 1.0.7
-        version: 1.0.7(@types/babel__core@7.20.5)(postcss@8.5.6)(rollup@4.53.2)(tslib@2.6.3)(typescript@5.9.3)
+        version: 1.0.7(@types/babel__core@7.20.5)(postcss@8.5.6)(rollup@4.62.2)(tslib@2.6.3)(typescript@5.9.3)
       '@types/react':
         specifier: 19.2.7
         version: 19.2.7
@@ -993,8 +993,8 @@ importers:
         specifier: 6.1.0
         version: 6.1.0
       rollup:
-        specifier: 4.53.2
-        version: 4.53.2
+        specifier: 4.62.2
+        version: 4.62.2
       typescript:
         specifier: 5.9.3
         version: 5.9.3
@@ -1025,7 +1025,7 @@ importers:
         version: 7.28.4
       '@nl-design-system/rollup-config-react-component':
         specifier: 1.0.7
-        version: 1.0.7(@types/babel__core@7.20.5)(postcss@8.5.6)(rollup@4.53.2)(tslib@2.6.3)(typescript@5.9.3)
+        version: 1.0.7(@types/babel__core@7.20.5)(postcss@8.5.6)(rollup@4.62.2)(tslib@2.6.3)(typescript@5.9.3)
       '@types/react':
         specifier: 19.2.7
         version: 19.2.7
@@ -1036,8 +1036,8 @@ importers:
         specifier: 6.1.0
         version: 6.1.0
       rollup:
-        specifier: 4.53.2
-        version: 4.53.2
+        specifier: 4.62.2
+        version: 4.62.2
       typescript:
         specifier: 5.9.3
         version: 5.9.3
@@ -1068,7 +1068,7 @@ importers:
         version: 7.28.4
       '@nl-design-system/rollup-config-react-component':
         specifier: 1.0.7
-        version: 1.0.7(@types/babel__core@7.20.5)(postcss@8.5.6)(rollup@4.53.2)(tslib@2.6.3)(typescript@5.9.3)
+        version: 1.0.7(@types/babel__core@7.20.5)(postcss@8.5.6)(rollup@4.62.2)(tslib@2.6.3)(typescript@5.9.3)
       '@types/react':
         specifier: 19.2.7
         version: 19.2.7
@@ -1079,8 +1079,8 @@ importers:
         specifier: 6.1.0
         version: 6.1.0
       rollup:
-        specifier: 4.53.2
-        version: 4.53.2
+        specifier: 4.62.2
+        version: 4.62.2
       typescript:
         specifier: 5.9.3
         version: 5.9.3
@@ -1095,7 +1095,7 @@ importers:
         version: link:../../components-react/alert-react
       '@storybook/react-vite':
         specifier: 9.1.5
-        version: 9.1.5(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rollup@4.53.2)(storybook@9.1.16(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.3.6(@types/node@24.10.4)(sass@1.94.1)(yaml@2.8.1)))(typescript@5.9.3)(vite@7.3.6(@types/node@24.10.4)(sass@1.94.1)(yaml@2.8.1))
+        version: 9.1.5(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rollup@4.62.2)(storybook@9.1.16(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.3.6(@types/node@24.10.4)(sass@1.94.1)(yaml@2.8.1)))(typescript@5.9.3)(vite@7.3.6(@types/node@24.10.4)(sass@1.94.1)(yaml@2.8.1))
       '@types/react':
         specifier: 19.2.7
         version: 19.2.7
@@ -1110,7 +1110,7 @@ importers:
         version: link:../../components-react/button-react
       '@storybook/react-vite':
         specifier: 9.1.5
-        version: 9.1.5(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rollup@4.53.2)(storybook@9.1.16(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.3.6(@types/node@24.10.4)(sass@1.94.1)(yaml@2.8.1)))(typescript@5.9.3)(vite@7.3.6(@types/node@24.10.4)(sass@1.94.1)(yaml@2.8.1))
+        version: 9.1.5(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rollup@4.62.2)(storybook@9.1.16(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.3.6(@types/node@24.10.4)(sass@1.94.1)(yaml@2.8.1)))(typescript@5.9.3)(vite@7.3.6(@types/node@24.10.4)(sass@1.94.1)(yaml@2.8.1))
       '@types/react':
         specifier: 19.2.7
         version: 19.2.7
@@ -1125,7 +1125,7 @@ importers:
         version: link:../../components-react/code-block-react
       '@storybook/react-vite':
         specifier: 9.1.5
-        version: 9.1.5(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rollup@4.53.2)(storybook@9.1.16(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.3.6(@types/node@24.10.4)(sass@1.94.1)(yaml@2.8.1)))(typescript@5.9.3)(vite@7.3.6(@types/node@24.10.4)(sass@1.94.1)(yaml@2.8.1))
+        version: 9.1.5(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rollup@4.62.2)(storybook@9.1.16(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.3.6(@types/node@24.10.4)(sass@1.94.1)(yaml@2.8.1)))(typescript@5.9.3)(vite@7.3.6(@types/node@24.10.4)(sass@1.94.1)(yaml@2.8.1))
       '@types/react':
         specifier: 19.2.7
         version: 19.2.7
@@ -1140,7 +1140,7 @@ importers:
         version: link:../../components-react/code-react
       '@storybook/react-vite':
         specifier: 9.1.5
-        version: 9.1.5(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rollup@4.53.2)(storybook@9.1.16(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.3.6(@types/node@24.10.4)(sass@1.94.1)(yaml@2.8.1)))(typescript@5.9.3)(vite@7.3.6(@types/node@24.10.4)(sass@1.94.1)(yaml@2.8.1))
+        version: 9.1.5(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rollup@4.62.2)(storybook@9.1.16(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.3.6(@types/node@24.10.4)(sass@1.94.1)(yaml@2.8.1)))(typescript@5.9.3)(vite@7.3.6(@types/node@24.10.4)(sass@1.94.1)(yaml@2.8.1))
       '@types/react':
         specifier: 19.2.7
         version: 19.2.7
@@ -1155,7 +1155,7 @@ importers:
         version: link:../../components-react/color-sample-react
       '@storybook/react-vite':
         specifier: 9.1.5
-        version: 9.1.5(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rollup@4.53.2)(storybook@9.1.16(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.3.6(@types/node@24.10.4)(sass@1.94.1)(yaml@2.8.1)))(typescript@5.9.3)(vite@7.3.6(@types/node@24.10.4)(sass@1.94.1)(yaml@2.8.1))
+        version: 9.1.5(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rollup@4.62.2)(storybook@9.1.16(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.3.6(@types/node@24.10.4)(sass@1.94.1)(yaml@2.8.1)))(typescript@5.9.3)(vite@7.3.6(@types/node@24.10.4)(sass@1.94.1)(yaml@2.8.1))
       '@types/react':
         specifier: 19.2.7
         version: 19.2.7
@@ -1170,7 +1170,7 @@ importers:
         version: link:../../components-react/data-badge-react
       '@storybook/react-vite':
         specifier: 9.1.5
-        version: 9.1.5(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rollup@4.53.2)(storybook@9.1.16(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.3.6(@types/node@24.10.4)(sass@1.94.1)(yaml@2.8.1)))(typescript@5.9.3)(vite@7.3.6(@types/node@24.10.4)(sass@1.94.1)(yaml@2.8.1))
+        version: 9.1.5(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rollup@4.62.2)(storybook@9.1.16(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.3.6(@types/node@24.10.4)(sass@1.94.1)(yaml@2.8.1)))(typescript@5.9.3)(vite@7.3.6(@types/node@24.10.4)(sass@1.94.1)(yaml@2.8.1))
       '@types/react':
         specifier: 19.2.7
         version: 19.2.7
@@ -1185,7 +1185,7 @@ importers:
         version: link:../../components-react/form-field-description-react
       '@storybook/react-vite':
         specifier: 9.1.5
-        version: 9.1.5(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rollup@4.53.2)(storybook@9.1.16(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.3.6(@types/node@24.10.4)(sass@1.94.1)(yaml@2.8.1)))(typescript@5.9.3)(vite@7.3.6(@types/node@24.10.4)(sass@1.94.1)(yaml@2.8.1))
+        version: 9.1.5(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rollup@4.62.2)(storybook@9.1.16(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.3.6(@types/node@24.10.4)(sass@1.94.1)(yaml@2.8.1)))(typescript@5.9.3)(vite@7.3.6(@types/node@24.10.4)(sass@1.94.1)(yaml@2.8.1))
       '@types/react':
         specifier: 19.2.7
         version: 19.2.7
@@ -1200,7 +1200,7 @@ importers:
         version: link:../../components-react/form-field-error-message-react
       '@storybook/react-vite':
         specifier: 9.1.5
-        version: 9.1.5(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rollup@4.53.2)(storybook@9.1.16(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.3.6(@types/node@24.10.4)(sass@1.94.1)(yaml@2.8.1)))(typescript@5.9.3)(vite@7.3.6(@types/node@24.10.4)(sass@1.94.1)(yaml@2.8.1))
+        version: 9.1.5(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rollup@4.62.2)(storybook@9.1.16(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.3.6(@types/node@24.10.4)(sass@1.94.1)(yaml@2.8.1)))(typescript@5.9.3)(vite@7.3.6(@types/node@24.10.4)(sass@1.94.1)(yaml@2.8.1))
       '@types/react':
         specifier: 19.2.7
         version: 19.2.7
@@ -1215,7 +1215,7 @@ importers:
         version: link:../../components-react/form-field-label-react
       '@storybook/react-vite':
         specifier: 9.1.5
-        version: 9.1.5(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rollup@4.53.2)(storybook@9.1.16(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.3.6(@types/node@24.10.4)(sass@1.94.1)(yaml@2.8.1)))(typescript@5.9.3)(vite@7.3.6(@types/node@24.10.4)(sass@1.94.1)(yaml@2.8.1))
+        version: 9.1.5(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rollup@4.62.2)(storybook@9.1.16(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.3.6(@types/node@24.10.4)(sass@1.94.1)(yaml@2.8.1)))(typescript@5.9.3)(vite@7.3.6(@types/node@24.10.4)(sass@1.94.1)(yaml@2.8.1))
       '@types/react':
         specifier: 19.2.7
         version: 19.2.7
@@ -1233,7 +1233,7 @@ importers:
         version: link:../../components-react/paragraph-react
       '@storybook/react-vite':
         specifier: 9.1.5
-        version: 9.1.5(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rollup@4.53.2)(storybook@9.1.16(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.3.6(@types/node@24.10.4)(sass@1.94.1)(yaml@2.8.1)))(typescript@5.9.3)(vite@7.3.6(@types/node@24.10.4)(sass@1.94.1)(yaml@2.8.1))
+        version: 9.1.5(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rollup@4.62.2)(storybook@9.1.16(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.3.6(@types/node@24.10.4)(sass@1.94.1)(yaml@2.8.1)))(typescript@5.9.3)(vite@7.3.6(@types/node@24.10.4)(sass@1.94.1)(yaml@2.8.1))
       '@types/react':
         specifier: 19.2.7
         version: 19.2.7
@@ -1248,7 +1248,7 @@ importers:
         version: link:../../components-react/icon-react
       '@storybook/react-vite':
         specifier: 9.1.5
-        version: 9.1.5(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rollup@4.53.2)(storybook@9.1.16(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.3.6(@types/node@24.10.4)(sass@1.94.1)(yaml@2.8.1)))(typescript@5.9.3)(vite@7.3.6(@types/node@24.10.4)(sass@1.94.1)(yaml@2.8.1))
+        version: 9.1.5(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rollup@4.62.2)(storybook@9.1.16(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.3.6(@types/node@24.10.4)(sass@1.94.1)(yaml@2.8.1)))(typescript@5.9.3)(vite@7.3.6(@types/node@24.10.4)(sass@1.94.1)(yaml@2.8.1))
       '@types/react':
         specifier: 19.2.7
         version: 19.2.7
@@ -1263,7 +1263,7 @@ importers:
         version: link:../../components-react/link-react
       '@storybook/react-vite':
         specifier: 9.1.5
-        version: 9.1.5(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rollup@4.53.2)(storybook@9.1.16(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.3.6(@types/node@24.10.4)(sass@1.94.1)(yaml@2.8.1)))(typescript@5.9.3)(vite@7.3.6(@types/node@24.10.4)(sass@1.94.1)(yaml@2.8.1))
+        version: 9.1.5(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rollup@4.62.2)(storybook@9.1.16(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.3.6(@types/node@24.10.4)(sass@1.94.1)(yaml@2.8.1)))(typescript@5.9.3)(vite@7.3.6(@types/node@24.10.4)(sass@1.94.1)(yaml@2.8.1))
       '@types/react':
         specifier: 19.2.7
         version: 19.2.7
@@ -1278,7 +1278,7 @@ importers:
         version: link:../../components-react/mark-react
       '@storybook/react-vite':
         specifier: 9.1.5
-        version: 9.1.5(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rollup@4.53.2)(storybook@9.1.16(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.3.6(@types/node@24.10.4)(sass@1.94.1)(yaml@2.8.1)))(typescript@5.9.3)(vite@7.3.6(@types/node@24.10.4)(sass@1.94.1)(yaml@2.8.1))
+        version: 9.1.5(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rollup@4.62.2)(storybook@9.1.16(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.3.6(@types/node@24.10.4)(sass@1.94.1)(yaml@2.8.1)))(typescript@5.9.3)(vite@7.3.6(@types/node@24.10.4)(sass@1.94.1)(yaml@2.8.1))
       '@types/react':
         specifier: 19.2.7
         version: 19.2.7
@@ -1293,7 +1293,7 @@ importers:
         version: link:../../components-react/number-badge-react
       '@storybook/react-vite':
         specifier: 9.1.5
-        version: 9.1.5(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rollup@4.53.2)(storybook@9.1.16(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.3.6(@types/node@24.10.4)(sass@1.94.1)(yaml@2.8.1)))(typescript@5.9.3)(vite@7.3.6(@types/node@24.10.4)(sass@1.94.1)(yaml@2.8.1))
+        version: 9.1.5(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rollup@4.62.2)(storybook@9.1.16(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.3.6(@types/node@24.10.4)(sass@1.94.1)(yaml@2.8.1)))(typescript@5.9.3)(vite@7.3.6(@types/node@24.10.4)(sass@1.94.1)(yaml@2.8.1))
       '@types/react':
         specifier: 19.2.7
         version: 19.2.7
@@ -1308,7 +1308,7 @@ importers:
         version: link:../../components-react/ordered-list-react
       '@storybook/react-vite':
         specifier: 9.1.5
-        version: 9.1.5(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rollup@4.53.2)(storybook@9.1.16(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.3.6(@types/node@24.10.4)(sass@1.94.1)(yaml@2.8.1)))(typescript@5.9.3)(vite@7.3.6(@types/node@24.10.4)(sass@1.94.1)(yaml@2.8.1))
+        version: 9.1.5(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rollup@4.62.2)(storybook@9.1.16(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.3.6(@types/node@24.10.4)(sass@1.94.1)(yaml@2.8.1)))(typescript@5.9.3)(vite@7.3.6(@types/node@24.10.4)(sass@1.94.1)(yaml@2.8.1))
       '@types/react':
         specifier: 19.2.7
         version: 19.2.7
@@ -1323,7 +1323,7 @@ importers:
         version: link:../../components-react/paragraph-react
       '@storybook/react-vite':
         specifier: 9.1.5
-        version: 9.1.5(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rollup@4.53.2)(storybook@9.1.16(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.3.6(@types/node@24.10.4)(sass@1.94.1)(yaml@2.8.1)))(typescript@5.9.3)(vite@7.3.6(@types/node@24.10.4)(sass@1.94.1)(yaml@2.8.1))
+        version: 9.1.5(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rollup@4.62.2)(storybook@9.1.16(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.3.6(@types/node@24.10.4)(sass@1.94.1)(yaml@2.8.1)))(typescript@5.9.3)(vite@7.3.6(@types/node@24.10.4)(sass@1.94.1)(yaml@2.8.1))
       '@types/react':
         specifier: 19.2.7
         version: 19.2.7
@@ -1338,7 +1338,7 @@ importers:
         version: link:../../components-react/skip-link-react
       '@storybook/react-vite':
         specifier: 9.1.5
-        version: 9.1.5(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rollup@4.53.2)(storybook@9.1.16(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.3.6(@types/node@24.10.4)(sass@1.94.1)(yaml@2.8.1)))(typescript@5.9.3)(vite@7.3.6(@types/node@24.10.4)(sass@1.94.1)(yaml@2.8.1))
+        version: 9.1.5(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rollup@4.62.2)(storybook@9.1.16(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.3.6(@types/node@24.10.4)(sass@1.94.1)(yaml@2.8.1)))(typescript@5.9.3)(vite@7.3.6(@types/node@24.10.4)(sass@1.94.1)(yaml@2.8.1))
       '@types/react':
         specifier: 19.2.7
         version: 19.2.7
@@ -1353,7 +1353,7 @@ importers:
         version: link:../../components-react/text-input-react
       '@storybook/react-vite':
         specifier: 9.1.5
-        version: 9.1.5(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rollup@4.53.2)(storybook@9.1.16(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.3.6(@types/node@24.10.4)(sass@1.94.1)(yaml@2.8.1)))(typescript@5.9.3)(vite@7.3.6(@types/node@24.10.4)(sass@1.94.1)(yaml@2.8.1))
+        version: 9.1.5(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rollup@4.62.2)(storybook@9.1.16(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.3.6(@types/node@24.10.4)(sass@1.94.1)(yaml@2.8.1)))(typescript@5.9.3)(vite@7.3.6(@types/node@24.10.4)(sass@1.94.1)(yaml@2.8.1))
       '@types/react':
         specifier: 19.2.7
         version: 19.2.7
@@ -1368,7 +1368,7 @@ importers:
         version: link:../../components-react/unordered-list-react
       '@storybook/react-vite':
         specifier: 9.1.5
-        version: 9.1.5(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rollup@4.53.2)(storybook@9.1.16(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.3.6(@types/node@24.10.4)(sass@1.94.1)(yaml@2.8.1)))(typescript@5.9.3)(vite@7.3.6(@types/node@24.10.4)(sass@1.94.1)(yaml@2.8.1))
+        version: 9.1.5(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rollup@4.62.2)(storybook@9.1.16(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.3.6(@types/node@24.10.4)(sass@1.94.1)(yaml@2.8.1)))(typescript@5.9.3)(vite@7.3.6(@types/node@24.10.4)(sass@1.94.1)(yaml@2.8.1))
       '@types/react':
         specifier: 19.2.7
         version: 19.2.7
@@ -1503,7 +1503,7 @@ importers:
         version: 9.1.16(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(storybook@9.1.16(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.3.6(@types/node@24.10.4)(sass@1.94.1)(yaml@2.8.1)))(typescript@5.9.3)
       '@storybook/react-vite':
         specifier: 9.1.16
-        version: 9.1.16(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rollup@4.53.2)(storybook@9.1.16(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.3.6(@types/node@24.10.4)(sass@1.94.1)(yaml@2.8.1)))(typescript@5.9.3)(vite@7.3.6(@types/node@24.10.4)(sass@1.94.1)(yaml@2.8.1))
+        version: 9.1.16(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rollup@4.62.2)(storybook@9.1.16(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.3.6(@types/node@24.10.4)(sass@1.94.1)(yaml@2.8.1)))(typescript@5.9.3)(vite@7.3.6(@types/node@24.10.4)(sass@1.94.1)(yaml@2.8.1))
       '@tabler/icons-react':
         specifier: 3.35.0
         version: 3.35.0(react@19.2.3)
@@ -1575,7 +1575,7 @@ importers:
         version: 9.1.16(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(storybook@9.1.16(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.3.6(@types/node@24.10.4)(sass@1.94.1)(yaml@2.8.1)))(typescript@5.9.3)
       '@storybook/react-vite':
         specifier: 9.1.16
-        version: 9.1.16(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rollup@4.53.2)(storybook@9.1.16(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.3.6(@types/node@24.10.4)(sass@1.94.1)(yaml@2.8.1)))(typescript@5.9.3)(vite@7.3.6(@types/node@24.10.4)(sass@1.94.1)(yaml@2.8.1))
+        version: 9.1.16(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rollup@4.62.2)(storybook@9.1.16(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.3.6(@types/node@24.10.4)(sass@1.94.1)(yaml@2.8.1)))(typescript@5.9.3)(vite@7.3.6(@types/node@24.10.4)(sass@1.94.1)(yaml@2.8.1))
       '@tabler/icons-react':
         specifier: 3.35.0
         version: 3.35.0(react@19.2.3)
@@ -1629,7 +1629,7 @@ importers:
         version: 9.1.16(@types/react@19.2.7)(storybook@9.1.16(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.3.6(@types/node@24.10.4)(sass@1.94.1)(yaml@2.8.1)))
       '@storybook/react-vite':
         specifier: 9.1.16
-        version: 9.1.16(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rollup@4.53.2)(storybook@9.1.16(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.3.6(@types/node@24.10.4)(sass@1.94.1)(yaml@2.8.1)))(typescript@5.9.3)(vite@7.3.6(@types/node@24.10.4)(sass@1.94.1)(yaml@2.8.1))
+        version: 9.1.16(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rollup@4.62.2)(storybook@9.1.16(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.3.6(@types/node@24.10.4)(sass@1.94.1)(yaml@2.8.1)))(typescript@5.9.3)(vite@7.3.6(@types/node@24.10.4)(sass@1.94.1)(yaml@2.8.1))
       '@types/react':
         specifier: 19.2.7
         version: 19.2.7
@@ -1689,7 +1689,7 @@ importers:
         version: 9.1.16(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(storybook@9.1.16(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.3.6(@types/node@24.10.4)(sass@1.94.1)(yaml@2.8.1)))(typescript@5.9.3)
       '@storybook/react-vite':
         specifier: 9.1.16
-        version: 9.1.16(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rollup@4.53.2)(storybook@9.1.16(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.3.6(@types/node@24.10.4)(sass@1.94.1)(yaml@2.8.1)))(typescript@5.9.3)(vite@7.3.6(@types/node@24.10.4)(sass@1.94.1)(yaml@2.8.1))
+        version: 9.1.16(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rollup@4.62.2)(storybook@9.1.16(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.3.6(@types/node@24.10.4)(sass@1.94.1)(yaml@2.8.1)))(typescript@5.9.3)(vite@7.3.6(@types/node@24.10.4)(sass@1.94.1)(yaml@2.8.1))
       '@tabler/icons-react':
         specifier: 3.35.0
         version: 3.35.0(react@19.2.3)
@@ -3222,8 +3222,18 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@rollup/rollup-android-arm-eabi@4.62.2':
+    resolution: {integrity: sha512-6o7ZLZK+BeenkZCFNDXqpbjw9bD6nuWonvS/lwQJp7NoVVxm6p3qE7qQ5jGuBjiFsgvqjD8mZAU5oWxTmbOeOg==}
+    cpu: [arm]
+    os: [android]
+
   '@rollup/rollup-android-arm64@4.53.2':
     resolution: {integrity: sha512-k8FontTxIE7b0/OGKeSN5B6j25EuppBcWM33Z19JoVT7UTXFSo3D9CdU39wGTeb29NO3XxpMNauh09B+Ibw+9g==}
+    cpu: [arm64]
+    os: [android]
+
+  '@rollup/rollup-android-arm64@4.62.2':
+    resolution: {integrity: sha512-BaH7BllCACHoH1LguOU56UItGfUWjujlO65kS9LAodViaN4bwIKd7oeW/ZHJ/4ljr/7MIiENnNy3HJ0zXv8Zkw==}
     cpu: [arm64]
     os: [android]
 
@@ -3232,8 +3242,18 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  '@rollup/rollup-darwin-arm64@4.62.2':
+    resolution: {integrity: sha512-v39RCCvj4He82I9sFmk+M1VZ0PLM9sfsLVikjfx2hYBNALhrrOR2D3JjQA6AhlaSOgcR+RzrKY7e1+bT6SUO/A==}
+    cpu: [arm64]
+    os: [darwin]
+
   '@rollup/rollup-darwin-x64@4.53.2':
     resolution: {integrity: sha512-e6XqVmXlHrBlG56obu9gDRPW3O3hLxpwHpLsBJvuI8qqnsrtSZ9ERoWUXtPOkY8c78WghyPHZdmPhHLWNdAGEw==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rollup/rollup-darwin-x64@4.62.2':
+    resolution: {integrity: sha512-yl0y2vq3S3lHeuXhEdss6TWfKW8vkujImO12tn4ZkG/4oghr09LvdYm2RElVjokTQiUvDUGXLGsYeLqUMCKpGA==}
     cpu: [x64]
     os: [darwin]
 
@@ -3242,13 +3262,29 @@ packages:
     cpu: [arm64]
     os: [freebsd]
 
+  '@rollup/rollup-freebsd-arm64@4.62.2':
+    resolution: {integrity: sha512-tT4pvt4qXD+vEoezupCWi+a1F0vvDiksiHc+PxRlYTOH1I6/X4id9jPxTP+Fg+545euaFT1jJVs4CEdHZAU1vw==}
+    cpu: [arm64]
+    os: [freebsd]
+
   '@rollup/rollup-freebsd-x64@4.53.2':
     resolution: {integrity: sha512-ClAmAPx3ZCHtp6ysl4XEhWU69GUB1D+s7G9YjHGhIGCSrsg00nEGRRZHmINYxkdoJehde8VIsDC5t9C0gb6yqA==}
     cpu: [x64]
     os: [freebsd]
 
+  '@rollup/rollup-freebsd-x64@4.62.2':
+    resolution: {integrity: sha512-6nU5F2wCW+qvCBhTn1pdIU3bzsIoF7EUwsCDRxilWGprQR6yd508YnH9+OKFCwpfS8pjZqDUmnCAr7exax0XCg==}
+    cpu: [x64]
+    os: [freebsd]
+
   '@rollup/rollup-linux-arm-gnueabihf@4.53.2':
     resolution: {integrity: sha512-EPlb95nUsz6Dd9Qy13fI5kUPXNSljaG9FiJ4YUGU1O/Q77i5DYFW5KR8g1OzTcdZUqQQ1KdDqsTohdFVwCwjqg==}
+    cpu: [arm]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.62.2':
+    resolution: {integrity: sha512-n1GJHPOvpIfhi3TmrCeh6S6URt9BFCt0KQE3qvexyGCTAKpR4Lg+eWvNZEqu7epxwus/8ElT3hacYEucm49SZg==}
     cpu: [arm]
     os: [linux]
     libc: [glibc]
@@ -3259,8 +3295,20 @@ packages:
     os: [linux]
     libc: [musl]
 
+  '@rollup/rollup-linux-arm-musleabihf@4.62.2':
+    resolution: {integrity: sha512-JqgflS8wEB+UXV/vS1RpRbifGBeN4D5lz8D8oOFbFZw4vedvdOgCFAjfBmIMdW3yL10XpQQ0Ambepw6MXrhOnA==}
+    cpu: [arm]
+    os: [linux]
+    libc: [musl]
+
   '@rollup/rollup-linux-arm64-gnu@4.53.2':
     resolution: {integrity: sha512-Xt2byDZ+6OVNuREgBXr4+CZDJtrVso5woFtpKdGPhpTPHcNG7D8YXeQzpNbFRxzTVqJf7kvPMCub/pcGUWgBjA==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-arm64-gnu@4.62.2':
+    resolution: {integrity: sha512-wnFJkogWvN4jm/hQRF2UBaeUmk20j5+DmHvoyWii2b8HJDyvz1MF2OU/6ynXt2KR63rbZLWkFpoytpdc/yBuSA==}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
@@ -3271,11 +3319,29 @@ packages:
     os: [linux]
     libc: [musl]
 
+  '@rollup/rollup-linux-arm64-musl@4.62.2':
+    resolution: {integrity: sha512-HVu2bp0zhvJ8xHEV9+UUs7S90VadmBSY3LcIMvozbPo4AuMGDWlz3ymHLHZPX4hR67TKTt8Qp5PJ5RBg/i+RMQ==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
   '@rollup/rollup-linux-loong64-gnu@4.53.2':
     resolution: {integrity: sha512-8ms8sjmyc1jWJS6WdNSA23rEfdjWB30LH8Wqj0Cqvv7qSHnvw6kgMMXRdop6hkmGPlyYBdRPkjJnj3KCUHV/uQ==}
     cpu: [loong64]
     os: [linux]
     libc: [glibc]
+
+  '@rollup/rollup-linux-loong64-gnu@4.62.2':
+    resolution: {integrity: sha512-mQqqAV8QaoSgr9I2fKDLY2BAVvmKjWoGiu/cSYQonsLvtqwEn1E4QYfnCOcp5zoEqNhsDYin1s6jx/VJmrxlZg==}
+    cpu: [loong64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-loong64-musl@4.62.2':
+    resolution: {integrity: sha512-IxKLoxCQ2IWi6bT2akyDUBGsOImDKB+sPp4EsTmwFQ/fMwpCKm8uLSSgP/Kx/QYUgKis6SEZ5/Nlhup0DIA0PQ==}
+    cpu: [loong64]
+    os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.53.2':
     resolution: {integrity: sha512-3HRQLUQbpBDMmzoxPJYd3W6vrVHOo2cVW8RUo87Xz0JPJcBLBr5kZ1pGcQAhdZgX9VV7NbGNipah1omKKe23/g==}
@@ -3283,8 +3349,26 @@ packages:
     os: [linux]
     libc: [glibc]
 
+  '@rollup/rollup-linux-ppc64-gnu@4.62.2':
+    resolution: {integrity: sha512-Mk5ha2RQSgyFfmYYLkBpPnUk8D8FriBxesO1u9O75X0mHgXL1UQcH5Itl2lurWL2tj0RxV9b9tJgipac0hRY9A==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-ppc64-musl@4.62.2':
+    resolution: {integrity: sha512-CjvEnqJL/0/TQ3TXX3OPIJ/kmBellrWd4heXUmHeJlTnmwjKpSJzoehLaL6Xk0ZnMHBu9dZuFADNOrtjF4v+2w==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [musl]
+
   '@rollup/rollup-linux-riscv64-gnu@4.53.2':
     resolution: {integrity: sha512-fMjKi+ojnmIvhk34gZP94vjogXNNUKMEYs+EDaB/5TG/wUkoeua7p7VCHnE6T2Tx+iaghAqQX8teQzcvrYpaQA==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-riscv64-gnu@4.62.2':
+    resolution: {integrity: sha512-1SiZbzwdkaDURsew/tSOrooKiYy7EQGT6m8ufavAi9NEyQb/6VuIxFXAL1fqa4iZe3g4NbNk4P7J32z2tw5Mgg==}
     cpu: [riscv64]
     os: [linux]
     libc: [glibc]
@@ -3295,8 +3379,20 @@ packages:
     os: [linux]
     libc: [musl]
 
+  '@rollup/rollup-linux-riscv64-musl@4.62.2':
+    resolution: {integrity: sha512-nQts12zJ3NQRoE6uYljOH89v7szzLDvG2JD/vsX+vGXU8w/At1GowTZ5/7qeFQ8m7L55rpR8Okugnuo5bgjy2Q==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
   '@rollup/rollup-linux-s390x-gnu@4.53.2':
     resolution: {integrity: sha512-w6yjZF0P+NGzWR3AXWX9zc0DNEGdtvykB03uhonSHMRa+oWA6novflo2WaJr6JZakG2ucsyb+rvhrKac6NIy+w==}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-s390x-gnu@4.62.2':
+    resolution: {integrity: sha512-E9/ll019jhPIJgpzfZoIkBGhcz+kKNgVWYRY0zr9srBdPPFVpvOKW8VaJKUbeK+eZXyQF9ltME+Kk6affeaPgg==}
     cpu: [s390x]
     os: [linux]
     libc: [glibc]
@@ -3307,14 +3403,36 @@ packages:
     os: [linux]
     libc: [glibc]
 
+  '@rollup/rollup-linux-x64-gnu@4.62.2':
+    resolution: {integrity: sha512-5BqxR/pshjey51iliyzTD5Xi3EN0aLmQ2lZ3lvefVV9c82BvrLo2/6OT55iifpWBufs6kdwWbuOKS841DrmK9A==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
   '@rollup/rollup-linux-x64-musl@4.53.2':
     resolution: {integrity: sha512-ah59c1YkCxKExPP8O9PwOvs+XRLKwh/mV+3YdKqQ5AMQ0r4M4ZDuOrpWkUaqO7fzAHdINzV9tEVu8vNw48z0lA==}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
+  '@rollup/rollup-linux-x64-musl@4.62.2':
+    resolution: {integrity: sha512-uNN83XxQrRAh/w0/pmAfibcwyb6YWt4gP+dpnQKPVJshAloQ785ii8CT8ZCIxkGg9opVsvAlGhFitSm6D1Jjpg==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-openbsd-x64@4.62.2':
+    resolution: {integrity: sha512-srjEIxSH3LRnJN6THczDHWQplqEMFiAJrTab0msUryh9kwNpkICf3Ea6q6MN/2cZwRFUNx5w+h6Hpi4QuHS6Zg==}
+    cpu: [x64]
+    os: [openbsd]
+
   '@rollup/rollup-openharmony-arm64@4.53.2':
     resolution: {integrity: sha512-4VEd19Wmhr+Zy7hbUsFZ6YXEiP48hE//KPLCSVNY5RMGX2/7HZ+QkN55a3atM1C/BZCGIgqN+xrVgtdak2S9+A==}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rollup/rollup-openharmony-arm64@4.62.2':
+    resolution: {integrity: sha512-8hOJnxgbyObnCm5AlRA3A931xX19xq80RjVTKgJOvEKWqJruP/Uf12IbAOaDjjEXYRewwHLfmF0YRIdK3OwKWA==}
     cpu: [arm64]
     os: [openharmony]
 
@@ -3323,8 +3441,18 @@ packages:
     cpu: [arm64]
     os: [win32]
 
+  '@rollup/rollup-win32-arm64-msvc@4.62.2':
+    resolution: {integrity: sha512-mmF4AY1i0hG/bLWUctUq59gtmgaSIRa3cu/A3JFRp/sCNEme2bgDEiDS22P9FbnJB8NJNF4jPJiSP5RHQpUTDg==}
+    cpu: [arm64]
+    os: [win32]
+
   '@rollup/rollup-win32-ia32-msvc@4.53.2':
     resolution: {integrity: sha512-lNlPEGgdUfSzdCWU176ku/dQRnA7W+Gp8d+cWv73jYrb8uT7HTVVxq62DUYxjbaByuf1Yk0RIIAbDzp+CnOTFg==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@rollup/rollup-win32-ia32-msvc@4.62.2':
+    resolution: {integrity: sha512-DZgkknc6jhHrk46V25vbAM0zZkyP0nSDkJB8/dRkLTxv470dOmWDqGoEJl/9A0dFfS7yE3REOwNDxpHwSLSt0Q==}
     cpu: [ia32]
     os: [win32]
 
@@ -3333,8 +3461,18 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@rollup/rollup-win32-x64-gnu@4.62.2':
+    resolution: {integrity: sha512-T6xr6ucWSFto+VGajA8YH26LdpHRuP4YLHEKAtCWvJDOlnmWcDZVCI2Jmjr+IFHDlt2zRaTAKE4tfjTaWLgJBg==}
+    cpu: [x64]
+    os: [win32]
+
   '@rollup/rollup-win32-x64-msvc@4.53.2':
     resolution: {integrity: sha512-k+/Rkcyx//P6fetPoLMb8pBeqJBNGx81uuf7iljX9++yNBVRDQgD04L+SVXmXmh5ZP4/WOp4mWF0kmi06PW2tA==}
+    cpu: [x64]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-msvc@4.62.2':
+    resolution: {integrity: sha512-BfzEnDJOt9T8M989/lA37EcJgat01wLRnoi5dQf3QzOH7jzpqTAzdDbVfRljVr5r+jzKqpbHeyOfAaXxAd0PAA==}
     cpu: [x64]
     os: [win32]
 
@@ -3536,6 +3674,9 @@ packages:
 
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+
+  '@types/estree@1.0.9':
+    resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
 
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
@@ -6108,6 +6249,11 @@ packages:
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
+  rollup@4.62.2:
+    resolution: {integrity: sha512-RFnrW4lhXA3s3eqHDZvN654g8OTjzRfqpIRJYczCGB6HzphckVAi/Qh4tbPUbRuDi7s1Llv8g/NspLkttY3gTA==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+    hasBin: true
+
   run-con@1.3.2:
     resolution: {integrity: sha512-CcfE+mYiTcKEzg0IqS08+efdnH0oJ3zV0wSUFBNrMHMuxCtXvBCLzCJHatwuXDcu/RlhjTziTo/a1ruQik6/Yg==}
     hasBin: true
@@ -8335,15 +8481,15 @@ snapshots:
       - supports-color
       - typescript
 
-  '@nl-design-system/rollup-config-react-component@1.0.6(@types/babel__core@7.20.5)(postcss@8.5.6)(rollup@4.53.2)(tslib@2.6.3)(typescript@5.9.3)':
+  '@nl-design-system/rollup-config-react-component@1.0.6(@types/babel__core@7.20.5)(postcss@8.5.6)(rollup@4.62.2)(tslib@2.6.3)(typescript@5.9.3)':
     dependencies:
       '@babel/core': 7.28.0
-      '@rollup/plugin-babel': 6.0.4(@babel/core@7.28.0)(@types/babel__core@7.20.5)(rollup@4.53.2)
-      '@rollup/plugin-node-resolve': 16.0.1(rollup@4.53.2)
-      '@rollup/plugin-typescript': 12.1.4(rollup@4.53.2)(tslib@2.6.3)(typescript@5.9.3)
-      rollup: 4.53.2
-      rollup-plugin-node-externals: 8.0.1(rollup@4.53.2)
-      rollup-plugin-peer-deps-external: 2.2.4(rollup@4.53.2)
+      '@rollup/plugin-babel': 6.0.4(@babel/core@7.28.0)(@types/babel__core@7.20.5)(rollup@4.62.2)
+      '@rollup/plugin-node-resolve': 16.0.1(rollup@4.62.2)
+      '@rollup/plugin-typescript': 12.1.4(rollup@4.62.2)(tslib@2.6.3)(typescript@5.9.3)
+      rollup: 4.62.2
+      rollup-plugin-node-externals: 8.0.1(rollup@4.62.2)
+      rollup-plugin-peer-deps-external: 2.2.4(rollup@4.62.2)
       rollup-plugin-postcss: 4.0.2(postcss@8.5.6)
     transitivePeerDependencies:
       - '@types/babel__core'
@@ -8353,15 +8499,15 @@ snapshots:
       - tslib
       - typescript
 
-  '@nl-design-system/rollup-config-react-component@1.0.7(@types/babel__core@7.20.5)(postcss@8.5.6)(rollup@4.53.2)(tslib@2.6.3)(typescript@5.9.3)':
+  '@nl-design-system/rollup-config-react-component@1.0.7(@types/babel__core@7.20.5)(postcss@8.5.6)(rollup@4.62.2)(tslib@2.6.3)(typescript@5.9.3)':
     dependencies:
       '@babel/core': 7.28.5
-      '@rollup/plugin-babel': 6.1.0(@babel/core@7.28.5)(@types/babel__core@7.20.5)(rollup@4.53.2)
-      '@rollup/plugin-node-resolve': 16.0.3(rollup@4.53.2)
-      '@rollup/plugin-typescript': 12.3.0(rollup@4.53.2)(tslib@2.6.3)(typescript@5.9.3)
-      rollup: 4.53.2
-      rollup-plugin-node-externals: 8.1.1(rollup@4.53.2)
-      rollup-plugin-peer-deps-external: 2.2.4(rollup@4.53.2)
+      '@rollup/plugin-babel': 6.1.0(@babel/core@7.28.5)(@types/babel__core@7.20.5)(rollup@4.62.2)
+      '@rollup/plugin-node-resolve': 16.0.3(rollup@4.62.2)
+      '@rollup/plugin-typescript': 12.3.0(rollup@4.62.2)(tslib@2.6.3)(typescript@5.9.3)
+      rollup: 4.62.2
+      rollup-plugin-node-externals: 8.1.1(rollup@4.62.2)
+      rollup-plugin-peer-deps-external: 2.2.4(rollup@4.62.2)
       rollup-plugin-postcss: 4.0.2(postcss@8.5.6)
     transitivePeerDependencies:
       - '@types/babel__core'
@@ -8451,138 +8597,213 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@rollup/plugin-babel@6.0.4(@babel/core@7.28.0)(@types/babel__core@7.20.5)(rollup@4.53.2)':
+  '@rollup/plugin-babel@6.0.4(@babel/core@7.28.0)(@types/babel__core@7.20.5)(rollup@4.62.2)':
     dependencies:
       '@babel/core': 7.28.0
       '@babel/helper-module-imports': 7.27.1
-      '@rollup/pluginutils': 5.1.2(rollup@4.53.2)
+      '@rollup/pluginutils': 5.1.2(rollup@4.62.2)
     optionalDependencies:
       '@types/babel__core': 7.20.5
-      rollup: 4.53.2
+      rollup: 4.62.2
     transitivePeerDependencies:
       - supports-color
 
-  '@rollup/plugin-babel@6.1.0(@babel/core@7.28.5)(@types/babel__core@7.20.5)(rollup@4.53.2)':
+  '@rollup/plugin-babel@6.1.0(@babel/core@7.28.5)(@types/babel__core@7.20.5)(rollup@4.62.2)':
     dependencies:
       '@babel/core': 7.28.5
       '@babel/helper-module-imports': 7.27.1
-      '@rollup/pluginutils': 5.1.2(rollup@4.53.2)
+      '@rollup/pluginutils': 5.1.2(rollup@4.62.2)
     optionalDependencies:
       '@types/babel__core': 7.20.5
-      rollup: 4.53.2
+      rollup: 4.62.2
     transitivePeerDependencies:
       - supports-color
 
-  '@rollup/plugin-node-resolve@16.0.1(rollup@4.53.2)':
+  '@rollup/plugin-node-resolve@16.0.1(rollup@4.62.2)':
     dependencies:
-      '@rollup/pluginutils': 5.1.2(rollup@4.53.2)
+      '@rollup/pluginutils': 5.1.2(rollup@4.62.2)
       '@types/resolve': 1.20.2
       deepmerge: 4.3.1
       is-module: 1.0.0
       resolve: 1.22.10
     optionalDependencies:
-      rollup: 4.53.2
+      rollup: 4.62.2
 
-  '@rollup/plugin-node-resolve@16.0.3(rollup@4.53.2)':
+  '@rollup/plugin-node-resolve@16.0.3(rollup@4.62.2)':
     dependencies:
-      '@rollup/pluginutils': 5.1.2(rollup@4.53.2)
+      '@rollup/pluginutils': 5.1.2(rollup@4.62.2)
       '@types/resolve': 1.20.2
       deepmerge: 4.3.1
       is-module: 1.0.0
       resolve: 1.22.10
     optionalDependencies:
-      rollup: 4.53.2
+      rollup: 4.62.2
 
-  '@rollup/plugin-typescript@12.1.4(rollup@4.53.2)(tslib@2.6.3)(typescript@5.9.3)':
+  '@rollup/plugin-typescript@12.1.4(rollup@4.62.2)(tslib@2.6.3)(typescript@5.9.3)':
     dependencies:
-      '@rollup/pluginutils': 5.1.2(rollup@4.53.2)
+      '@rollup/pluginutils': 5.1.2(rollup@4.62.2)
       resolve: 1.22.10
       typescript: 5.9.3
     optionalDependencies:
-      rollup: 4.53.2
+      rollup: 4.62.2
       tslib: 2.6.3
 
-  '@rollup/plugin-typescript@12.3.0(rollup@4.53.2)(tslib@2.6.3)(typescript@5.9.3)':
+  '@rollup/plugin-typescript@12.3.0(rollup@4.62.2)(tslib@2.6.3)(typescript@5.9.3)':
     dependencies:
-      '@rollup/pluginutils': 5.1.2(rollup@4.53.2)
+      '@rollup/pluginutils': 5.1.2(rollup@4.62.2)
       resolve: 1.22.10
       typescript: 5.9.3
     optionalDependencies:
-      rollup: 4.53.2
+      rollup: 4.62.2
       tslib: 2.6.3
 
-  '@rollup/pluginutils@5.1.2(rollup@4.53.2)':
+  '@rollup/pluginutils@5.1.2(rollup@4.62.2)':
     dependencies:
       '@types/estree': 1.0.8
       estree-walker: 2.0.2
       picomatch: 2.3.1
     optionalDependencies:
-      rollup: 4.53.2
+      rollup: 4.62.2
 
   '@rollup/rollup-android-arm-eabi@4.53.2':
+    optional: true
+
+  '@rollup/rollup-android-arm-eabi@4.62.2':
     optional: true
 
   '@rollup/rollup-android-arm64@4.53.2':
     optional: true
 
+  '@rollup/rollup-android-arm64@4.62.2':
+    optional: true
+
   '@rollup/rollup-darwin-arm64@4.53.2':
+    optional: true
+
+  '@rollup/rollup-darwin-arm64@4.62.2':
     optional: true
 
   '@rollup/rollup-darwin-x64@4.53.2':
     optional: true
 
+  '@rollup/rollup-darwin-x64@4.62.2':
+    optional: true
+
   '@rollup/rollup-freebsd-arm64@4.53.2':
+    optional: true
+
+  '@rollup/rollup-freebsd-arm64@4.62.2':
     optional: true
 
   '@rollup/rollup-freebsd-x64@4.53.2':
     optional: true
 
+  '@rollup/rollup-freebsd-x64@4.62.2':
+    optional: true
+
   '@rollup/rollup-linux-arm-gnueabihf@4.53.2':
+    optional: true
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.62.2':
     optional: true
 
   '@rollup/rollup-linux-arm-musleabihf@4.53.2':
     optional: true
 
+  '@rollup/rollup-linux-arm-musleabihf@4.62.2':
+    optional: true
+
   '@rollup/rollup-linux-arm64-gnu@4.53.2':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-gnu@4.62.2':
     optional: true
 
   '@rollup/rollup-linux-arm64-musl@4.53.2':
     optional: true
 
+  '@rollup/rollup-linux-arm64-musl@4.62.2':
+    optional: true
+
   '@rollup/rollup-linux-loong64-gnu@4.53.2':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-gnu@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-musl@4.62.2':
     optional: true
 
   '@rollup/rollup-linux-ppc64-gnu@4.53.2':
     optional: true
 
+  '@rollup/rollup-linux-ppc64-gnu@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-musl@4.62.2':
+    optional: true
+
   '@rollup/rollup-linux-riscv64-gnu@4.53.2':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-gnu@4.62.2':
     optional: true
 
   '@rollup/rollup-linux-riscv64-musl@4.53.2':
     optional: true
 
+  '@rollup/rollup-linux-riscv64-musl@4.62.2':
+    optional: true
+
   '@rollup/rollup-linux-s390x-gnu@4.53.2':
+    optional: true
+
+  '@rollup/rollup-linux-s390x-gnu@4.62.2':
     optional: true
 
   '@rollup/rollup-linux-x64-gnu@4.53.2':
     optional: true
 
+  '@rollup/rollup-linux-x64-gnu@4.62.2':
+    optional: true
+
   '@rollup/rollup-linux-x64-musl@4.53.2':
+    optional: true
+
+  '@rollup/rollup-linux-x64-musl@4.62.2':
+    optional: true
+
+  '@rollup/rollup-openbsd-x64@4.62.2':
     optional: true
 
   '@rollup/rollup-openharmony-arm64@4.53.2':
     optional: true
 
+  '@rollup/rollup-openharmony-arm64@4.62.2':
+    optional: true
+
   '@rollup/rollup-win32-arm64-msvc@4.53.2':
+    optional: true
+
+  '@rollup/rollup-win32-arm64-msvc@4.62.2':
     optional: true
 
   '@rollup/rollup-win32-ia32-msvc@4.53.2':
     optional: true
 
+  '@rollup/rollup-win32-ia32-msvc@4.62.2':
+    optional: true
+
   '@rollup/rollup-win32-x64-gnu@4.53.2':
     optional: true
 
+  '@rollup/rollup-win32-x64-gnu@4.62.2':
+    optional: true
+
   '@rollup/rollup-win32-x64-msvc@4.53.2':
+    optional: true
+
+  '@rollup/rollup-win32-x64-msvc@4.62.2':
     optional: true
 
   '@standard-schema/spec@1.1.0': {}
@@ -8687,10 +8908,10 @@ snapshots:
       react-dom: 19.2.3(react@19.2.3)
       storybook: 9.1.16(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.3.6(@types/node@24.10.4)(sass@1.94.1)(yaml@2.8.1))
 
-  '@storybook/react-vite@9.1.16(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rollup@4.53.2)(storybook@9.1.16(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.3.6(@types/node@24.10.4)(sass@1.94.1)(yaml@2.8.1)))(typescript@5.9.3)(vite@7.3.6(@types/node@24.10.4)(sass@1.94.1)(yaml@2.8.1))':
+  '@storybook/react-vite@9.1.16(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rollup@4.62.2)(storybook@9.1.16(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.3.6(@types/node@24.10.4)(sass@1.94.1)(yaml@2.8.1)))(typescript@5.9.3)(vite@7.3.6(@types/node@24.10.4)(sass@1.94.1)(yaml@2.8.1))':
     dependencies:
       '@joshwooding/vite-plugin-react-docgen-typescript': 0.6.1(typescript@5.9.3)(vite@7.3.6(@types/node@24.10.4)(sass@1.94.1)(yaml@2.8.1))
-      '@rollup/pluginutils': 5.1.2(rollup@4.53.2)
+      '@rollup/pluginutils': 5.1.2(rollup@4.62.2)
       '@storybook/builder-vite': 9.1.16(storybook@9.1.16(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.3.6(@types/node@24.10.4)(sass@1.94.1)(yaml@2.8.1)))(vite@7.3.6(@types/node@24.10.4)(sass@1.94.1)(yaml@2.8.1))
       '@storybook/react': 9.1.16(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(storybook@9.1.16(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.3.6(@types/node@24.10.4)(sass@1.94.1)(yaml@2.8.1)))(typescript@5.9.3)
       find-up: 7.0.0
@@ -8707,10 +8928,10 @@ snapshots:
       - supports-color
       - typescript
 
-  '@storybook/react-vite@9.1.5(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rollup@4.53.2)(storybook@9.1.16(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.3.6(@types/node@24.10.4)(sass@1.94.1)(yaml@2.8.1)))(typescript@5.9.3)(vite@7.3.6(@types/node@24.10.4)(sass@1.94.1)(yaml@2.8.1))':
+  '@storybook/react-vite@9.1.5(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rollup@4.62.2)(storybook@9.1.16(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.3.6(@types/node@24.10.4)(sass@1.94.1)(yaml@2.8.1)))(typescript@5.9.3)(vite@7.3.6(@types/node@24.10.4)(sass@1.94.1)(yaml@2.8.1))':
     dependencies:
       '@joshwooding/vite-plugin-react-docgen-typescript': 0.6.1(typescript@5.9.3)(vite@7.3.6(@types/node@24.10.4)(sass@1.94.1)(yaml@2.8.1))
-      '@rollup/pluginutils': 5.1.2(rollup@4.53.2)
+      '@rollup/pluginutils': 5.1.2(rollup@4.62.2)
       '@storybook/builder-vite': 9.1.5(storybook@9.1.16(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.3.6(@types/node@24.10.4)(sass@1.94.1)(yaml@2.8.1)))(vite@7.3.6(@types/node@24.10.4)(sass@1.94.1)(yaml@2.8.1))
       '@storybook/react': 9.1.5(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(storybook@9.1.16(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.3.6(@types/node@24.10.4)(sass@1.94.1)(yaml@2.8.1)))(typescript@5.9.3)
       find-up: 7.0.0
@@ -8838,6 +9059,8 @@ snapshots:
   '@types/doctrine@0.0.9': {}
 
   '@types/estree@1.0.8': {}
+
+  '@types/estree@1.0.9': {}
 
   '@types/json-schema@7.0.15': {}
 
@@ -11765,17 +11988,17 @@ snapshots:
       glob: 12.0.0
       package-json-from-dist: 1.0.1
 
-  rollup-plugin-node-externals@8.0.1(rollup@4.53.2):
+  rollup-plugin-node-externals@8.0.1(rollup@4.62.2):
     dependencies:
-      rollup: 4.53.2
+      rollup: 4.62.2
 
-  rollup-plugin-node-externals@8.1.1(rollup@4.53.2):
+  rollup-plugin-node-externals@8.1.1(rollup@4.62.2):
     dependencies:
-      rollup: 4.53.2
+      rollup: 4.62.2
 
-  rollup-plugin-peer-deps-external@2.2.4(rollup@4.53.2):
+  rollup-plugin-peer-deps-external@2.2.4(rollup@4.62.2):
     dependencies:
-      rollup: 4.53.2
+      rollup: 4.62.2
 
   rollup-plugin-postcss@4.0.2(postcss@8.5.6):
     dependencies:
@@ -11826,6 +12049,37 @@ snapshots:
       '@rollup/rollup-win32-ia32-msvc': 4.53.2
       '@rollup/rollup-win32-x64-gnu': 4.53.2
       '@rollup/rollup-win32-x64-msvc': 4.53.2
+      fsevents: 2.3.3
+
+  rollup@4.62.2:
+    dependencies:
+      '@types/estree': 1.0.9
+    optionalDependencies:
+      '@rollup/rollup-android-arm-eabi': 4.62.2
+      '@rollup/rollup-android-arm64': 4.62.2
+      '@rollup/rollup-darwin-arm64': 4.62.2
+      '@rollup/rollup-darwin-x64': 4.62.2
+      '@rollup/rollup-freebsd-arm64': 4.62.2
+      '@rollup/rollup-freebsd-x64': 4.62.2
+      '@rollup/rollup-linux-arm-gnueabihf': 4.62.2
+      '@rollup/rollup-linux-arm-musleabihf': 4.62.2
+      '@rollup/rollup-linux-arm64-gnu': 4.62.2
+      '@rollup/rollup-linux-arm64-musl': 4.62.2
+      '@rollup/rollup-linux-loong64-gnu': 4.62.2
+      '@rollup/rollup-linux-loong64-musl': 4.62.2
+      '@rollup/rollup-linux-ppc64-gnu': 4.62.2
+      '@rollup/rollup-linux-ppc64-musl': 4.62.2
+      '@rollup/rollup-linux-riscv64-gnu': 4.62.2
+      '@rollup/rollup-linux-riscv64-musl': 4.62.2
+      '@rollup/rollup-linux-s390x-gnu': 4.62.2
+      '@rollup/rollup-linux-x64-gnu': 4.62.2
+      '@rollup/rollup-linux-x64-musl': 4.62.2
+      '@rollup/rollup-openbsd-x64': 4.62.2
+      '@rollup/rollup-openharmony-arm64': 4.62.2
+      '@rollup/rollup-win32-arm64-msvc': 4.62.2
+      '@rollup/rollup-win32-ia32-msvc': 4.62.2
+      '@rollup/rollup-win32-x64-gnu': 4.62.2
+      '@rollup/rollup-win32-x64-msvc': 4.62.2
       fsevents: 2.3.3
 
   run-con@1.3.2:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,7 @@ settings:
 
 overrides:
   glob: ^11.1.0 || ^12.0.0
+  vite@>=7.0.0 <=7.3.4: ^7.3.5
 
 importers:
 
@@ -2968,7 +2969,7 @@ packages:
     resolution: {integrity: sha512-J4BaTocTOYFkMHIra1JDWrMWpNmBl4EkplIwHEsV8aeUOtdWjwSnln9U7twjMFTAEB7mptNtSKyVi1Y2W9sDJw==}
     peerDependencies:
       typescript: '>= 4.3.x'
-      vite: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
+      vite: ^7.3.5
     peerDependenciesMeta:
       typescript:
         optional: true
@@ -3505,13 +3506,13 @@ packages:
     resolution: {integrity: sha512-CyvYA5w1BKeSVaRavKi+euWxLffshq0v9Rz/5E9MKCitbYtjwkDH6UMIYmcbTs906mEBuYqrbz3nygDP0ppodw==}
     peerDependencies:
       storybook: ^9.1.16
-      vite: ^5.0.0 || ^6.0.0 || ^7.0.0
+      vite: ^7.3.5
 
   '@storybook/builder-vite@9.1.5':
     resolution: {integrity: sha512-sgt/9+Yl/5O7Bj5hdbHfadN8e/e4CNiDZKDcbLOMpOjKKoqF8vm19I1QocWIAiKjTOhF+4E9v9LddjtAGnfqHQ==}
     peerDependencies:
       storybook: ^9.1.5
-      vite: ^5.0.0 || ^6.0.0 || ^7.0.0
+      vite: ^7.3.5
 
   '@storybook/csf-plugin@9.1.16':
     resolution: {integrity: sha512-GKlNNlmWeFBQxhQY5hZOSnFGbeKq69jal0dYNWoSImTjor28eYRHb9iQkDzRpijLPizBaB9MlxLsLrgFDp7adA==}
@@ -3557,7 +3558,7 @@ packages:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta
       storybook: ^9.1.16
-      vite: ^5.0.0 || ^6.0.0 || ^7.0.0
+      vite: ^7.3.5
 
   '@storybook/react-vite@9.1.5':
     resolution: {integrity: sha512-OYbkHHNCrn8MNPd+4KxMjcSR4M/YHa84h8sWDUHhKRTRtZFmj8i/QDW3E8tGx2BRLxXw3dTYe9J5UYBhJDDxFA==}
@@ -3566,7 +3567,7 @@ packages:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta
       storybook: ^9.1.5
-      vite: ^5.0.0 || ^6.0.0 || ^7.0.0
+      vite: ^7.3.5
 
   '@storybook/react@9.1.16':
     resolution: {integrity: sha512-M/SkHJJdtiGpodBJq9+DYmSkEOD+VqlPxKI+FvbHESTNs//1IgqFIjEWetd8quhd9oj/gvo4ICBAPu+UmD6M9w==}
@@ -3819,7 +3820,7 @@ packages:
     resolution: {integrity: sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==}
     peerDependencies:
       msw: ^2.4.9
-      vite: ^5.0.0 || ^6.0.0 || ^7.0.0-0
+      vite: ^7.3.5
     peerDependenciesMeta:
       msw:
         optional: true
@@ -3830,7 +3831,7 @@ packages:
     resolution: {integrity: sha512-LEiN/xe4OSIbKe9HQIp5OC24agGD9J5CnmMgsLohVVoOPWL9a2sBoR6VBx43jQZb7Kr1l4RCuyCJzcAa0+dojw==}
     peerDependencies:
       msw: ^2.4.9
-      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+      vite: ^7.3.5
     peerDependenciesMeta:
       msw:
         optional: true
@@ -6797,46 +6798,6 @@ packages:
   vfile@6.0.3:
     resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
 
-  vite@7.2.2:
-    resolution: {integrity: sha512-BxAKBWmIbrDgrokdGZH1IgkIk/5mMHDreLDmCJ0qpyJaAteP8NvMhkwr/ZCQNqNH97bw/dANTE9PDzqwJghfMQ==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    hasBin: true
-    peerDependencies:
-      '@types/node': ^20.19.0 || >=22.12.0
-      jiti: '>=1.21.0'
-      less: ^4.0.0
-      lightningcss: ^1.21.0
-      sass: ^1.70.0
-      sass-embedded: ^1.70.0
-      stylus: '>=0.54.8'
-      sugarss: ^5.0.0
-      terser: ^5.16.0
-      tsx: ^4.8.1
-      yaml: ^2.4.2
-    peerDependenciesMeta:
-      '@types/node':
-        optional: true
-      jiti:
-        optional: true
-      less:
-        optional: true
-      lightningcss:
-        optional: true
-      sass:
-        optional: true
-      sass-embedded:
-        optional: true
-      stylus:
-        optional: true
-      sugarss:
-        optional: true
-      terser:
-        optional: true
-      tsx:
-        optional: true
-      yaml:
-        optional: true
-
   vite@7.3.6:
     resolution: {integrity: sha512-4XP60spRGjSZFf1qYH+dJIkK2znL3zQfl9KkOV9MkkRR/3Dls0dxaBsQPTloEc5BLXWPL9vsOxopxyKoMmDueg==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -9254,13 +9215,13 @@ snapshots:
     optionalDependencies:
       vite: 7.3.6(@types/node@24.10.4)(sass@1.94.1)(yaml@2.8.1)
 
-  '@vitest/mocker@4.1.8(vite@7.2.2(@types/node@24.10.4)(sass@1.94.1)(yaml@2.8.1))':
+  '@vitest/mocker@4.1.8(vite@7.3.6(@types/node@24.10.4)(sass@1.94.1)(yaml@2.8.1))':
     dependencies:
       '@vitest/spy': 4.1.8
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.2.2(@types/node@24.10.4)(sass@1.94.1)(yaml@2.8.1)
+      vite: 7.3.6(@types/node@24.10.4)(sass@1.94.1)(yaml@2.8.1)
 
   '@vitest/pretty-format@3.2.4':
     dependencies:
@@ -12730,20 +12691,6 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
-  vite@7.2.2(@types/node@24.10.4)(sass@1.94.1)(yaml@2.8.1):
-    dependencies:
-      esbuild: 0.25.3
-      fdir: 6.5.0(picomatch@4.0.3)
-      picomatch: 4.0.3
-      postcss: 8.5.6
-      rollup: 4.53.2
-      tinyglobby: 0.2.15
-    optionalDependencies:
-      '@types/node': 24.10.4
-      fsevents: 2.3.3
-      sass: 1.94.1
-      yaml: 2.8.1
-
   vite@7.3.6(@types/node@24.10.4)(sass@1.94.1)(yaml@2.8.1):
     dependencies:
       esbuild: 0.28.1
@@ -12761,7 +12708,7 @@ snapshots:
   vitest@4.1.8(@types/node@24.10.4)(@vitest/coverage-v8@4.1.8)(jsdom@27.2.0)(sass@1.94.1)(yaml@2.8.1):
     dependencies:
       '@vitest/expect': 4.1.8
-      '@vitest/mocker': 4.1.8(vite@7.2.2(@types/node@24.10.4)(sass@1.94.1)(yaml@2.8.1))
+      '@vitest/mocker': 4.1.8(vite@7.3.6(@types/node@24.10.4)(sass@1.94.1)(yaml@2.8.1))
       '@vitest/pretty-format': 4.1.8
       '@vitest/runner': 4.1.8
       '@vitest/snapshot': 4.1.8
@@ -12778,7 +12725,7 @@ snapshots:
       tinyexec: 1.2.4
       tinyglobby: 0.2.15
       tinyrainbow: 3.1.0
-      vite: 7.2.2(@types/node@24.10.4)(sass@1.94.1)(yaml@2.8.1)
+      vite: 7.3.6(@types/node@24.10.4)(sass@1.94.1)(yaml@2.8.1)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 24.10.4

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -12,6 +12,7 @@ allowBuilds:
 
 overrides:
   glob: ^11.1.0 || ^12.0.0
+  lodash@>=4.0.0 <=4.17.23: ^4.17.24
   vite@>=7.0.0 <=7.3.4: ^7.3.5
 
 # Configure pnpm so peer dependencies must be explicitly added instead of being automatically installed.

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -12,6 +12,7 @@ allowBuilds:
 
 overrides:
   glob: ^11.1.0 || ^12.0.0
+  vite@>=7.0.0 <=7.3.4: ^7.3.5
 
 # Configure pnpm so peer dependencies must be explicitly added instead of being automatically installed.
 autoInstallPeers: false


### PR DESCRIPTION
- **chore: upgrade rollup (fixes GHSA-mw96-cpmx-2vgc)**
- **chore: upgrade (override) vite (fixes GHSA-p9ff-h696-f583)**
- **chore: upgrade lodash-es (fixes GHSA-r5fr-rjxr-66jc)**
- **chore: upgrade (override) lodash (fixes GHSA-xxjr-mmjv-4gpg)**
