### PR TITLE
chore: move vercel configuration to vercel.json

### DIFF
--- a/packages/storybook-non-conforming/vercel.json
+++ b/packages/storybook-non-conforming/vercel.json
@@ -2,7 +2,7 @@
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "installCommand": "pnpm install --frozen-lockfile",
   "buildCommand": "cd ../.. && pnpm run build",
-  "framework": "storybook",
+  "framework": null,
   "outputDirectory": "dist",
   "git": {
     "deploymentEnabled": {

--- a/packages/storybook-non-conforming/vercel.json
+++ b/packages/storybook-non-conforming/vercel.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "installCommand": "pnpm install --frozen-lockfile",
+  "buildCommand": "cd ../.. && pnpm run build",
+  "framework": "storybook",
+  "outputDirectory": "dist",
+  "git": {
+    "deploymentEnabled": {
+      "dependabot/*": false,
+      "gh-pages": false
+    }
+  }
+}

--- a/packages/storybook-test/vercel.json
+++ b/packages/storybook-test/vercel.json
@@ -2,7 +2,7 @@
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "installCommand": "pnpm install --frozen-lockfile",
   "buildCommand": "cd ../.. && pnpm run build",
-  "framework": "storybook",
+  "framework": null,
   "outputDirectory": "dist",
   "git": {
     "deploymentEnabled": {

--- a/packages/storybook-test/vercel.json
+++ b/packages/storybook-test/vercel.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "installCommand": "pnpm install --frozen-lockfile",
+  "buildCommand": "cd ../.. && pnpm run build",
+  "framework": "storybook",
+  "outputDirectory": "dist",
+  "git": {
+    "deploymentEnabled": {
+      "dependabot/*": false,
+      "gh-pages": false
+    }
+  }
+}

--- a/packages/storybook/vercel.json
+++ b/packages/storybook/vercel.json
@@ -2,7 +2,7 @@
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "installCommand": "pnpm install --frozen-lockfile",
   "buildCommand": "cd ../.. && pnpm run build",
-  "framework": "storybook",
+  "framework": null,
   "outputDirectory": "dist",
   "git": {
     "deploymentEnabled": {

--- a/packages/storybook/vercel.json
+++ b/packages/storybook/vercel.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "installCommand": "pnpm install --frozen-lockfile",
+  "buildCommand": "cd ../.. && pnpm run build",
+  "framework": "storybook",
+  "outputDirectory": "dist",
+  "git": {
+    "deploymentEnabled": {
+      "dependabot/*": false,
+      "gh-pages": false
+    }
+  }
+}


### PR DESCRIPTION
This PR moves the vercel configuration to `vercel.json`.

It is part of an effort to have all vercel configuration in Terraform.  Some settings should "move with the code" and these will be kept in `vercel.json`.
