### PR TITLE
adjust github template tokens and npm

### DIFF
--- a/.github/ISSUE_TEMPLATE/208-📝-design-tokens-bepaald.md
+++ b/.github/ISSUE_TEMPLATE/208-📝-design-tokens-bepaald.md
@@ -112,7 +112,6 @@ Je kunt [design tokens ook als extensie toevoegen](https://www.nldesignsystem.nl
 
 - Leg de tokens vast in het `tokens.json` bestand van de component in de Candidate repository.
 - Zorg dat de design tokens NL Design System naming conventies volgen en zijn geprefixed met 'nl'.
-- Maak de tokens beschikbaar op NPM als `@nl-design-system-candidate/{component}-tokens`
 
 🚩 Checkpoint
 Design tokens bepaald

--- a/.github/ISSUE_TEMPLATE/501-🚀-gepubliceerd-op-npm.md
+++ b/.github/ISSUE_TEMPLATE/501-🚀-gepubliceerd-op-npm.md
@@ -12,7 +12,7 @@ type: Task
 
 Gebruik [de documentatie over het releasen van nieuwe candidate componenten](https://github.com/nl-design-system/candidate?tab=readme-ov-file#release-van-nieuwe-candidate-componenten)
 
-- [ ] Maak een pull-request aan om de NPM package publiek te maken (verwijder private: true uit package.json van het package)
+- [ ] Maak een pull-request aan om de NPM packages publiek te maken (verwijder private: true uit package.json van de packages)
 - [ ] Maak een changeset met major om de package te bumpen
 - [ ] Vraag het kernteam om een review zodat die gemerged wordt
 - [ ] `package.json#description` Nederlandstalig


### PR DESCRIPTION
Removed the instruction to publish tokens on NPM from steps to take. Now it part of the whole NPM publish step.